### PR TITLE
fix: docker socket proxy + release infrastructure

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -47,3 +47,6 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            OSA_VERSION=${{ github.event.release.tag_name || github.sha }}
+            OSA_REVISION=${{ github.sha }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,58 @@
+# Releasing OSA Server
+
+Open Science Archive (OSA) server images are published to
+`ghcr.io/opensciencearchive/osa`. Two kinds of tag exist:
+
+- **`sha-<short>`** — every merge to `main` produces one. Auditable but
+  not semantically meaningful. Useful for pinning to a specific commit
+  during development.
+- **`vX.Y.Z`** — produced when a GitHub Release is published with a
+  semver-shaped tag. This is the tag downstream deployments should pin.
+
+There is intentionally **no floating `:latest` tag**. OSA is consumed via
+a compose file with a pinned `OSA_IMAGE_TAG`, not via ad-hoc `docker pull`.
+
+## Cutting a release
+
+1. Ensure `main` is green — release-triggered builds do not gate on CI,
+   so a bad commit will publish a bad image. Check
+   `gh run list --workflow ci.yml --branch main --limit 1` first.
+
+2. Pick the next semver from the last release:
+   ```sh
+   gh release list --limit 1
+   ```
+   Bump patch for fixes, minor for backwards-compatible features, major
+   for breaking changes.
+
+3. Sync `server/pyproject.toml`'s `version` field to match the chosen
+   tag (without the `v` prefix). Commit on `main`.
+
+4. Cut the release from `main`:
+   ```sh
+   gh release create vX.Y.Z \
+     --target main \
+     --title "vX.Y.Z" \
+     --generate-notes
+   ```
+
+5. Watch the image build:
+   ```sh
+   gh run watch
+   ```
+   The image lands at `ghcr.io/opensciencearchive/osa:vX.Y.Z` within
+   ~5 minutes. The full commit SHA is embedded in the image's
+   `org.opencontainers.image.revision` label for traceability.
+
+6. Update downstream deployments (cultivarium pilot, etc.) to bump
+   `OSA_IMAGE_TAG` to the new version.
+
+## Verifying a published image
+
+```sh
+docker inspect ghcr.io/opensciencearchive/osa:vX.Y.Z \
+  --format '{{json .Config.Labels}}' | jq
+```
+
+You should see `org.opencontainers.image.version=vX.Y.Z` and a
+`revision` matching the commit you released from.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -24,20 +24,37 @@ services:
       OSA_BASE_URL: ${OSA_BASE_URL:-http://localhost:8000}
       OSA_LOGGING__LEVEL: ${LOG_LEVEL:-INFO}
       OSA_AUTH__JWT__SECRET: ${JWT_SECRET:-change-me-in-production-must-be-32-chars-long}
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
     depends_on:
       db:
         condition: service_healthy
+      docker-socket-proxy:
+        condition: service_started
     ports:
       - "${SERVER_PORT:-8000}:8000"
     volumes:
       - server_data:/data
-      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - default
+      - docker-proxy
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8000/api/v1/health"]
       interval: 30s
       timeout: 10s
       start_period: 10s
       retries: 3
+    restart: unless-stopped
+
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:v0.4.2
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      POST: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - docker-proxy
     restart: unless-stopped
 
   web:
@@ -58,3 +75,8 @@ services:
 volumes:
   postgres_data:
   server_data:
+
+networks:
+  default:
+  docker-proxy:
+    internal: true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       db:
         condition: service_healthy
       docker-socket-proxy:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "${SERVER_PORT:-8000}:8000"
     volumes:
@@ -55,6 +55,12 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - docker-proxy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:2375/_ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     restart: unless-stopped
 
   web:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,6 +33,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Stage 2: Runtime
 FROM python:3.13-slim-bookworm AS runtime
 
+ARG OSA_VERSION=dev
+ARG OSA_REVISION=unknown
+LABEL org.opencontainers.image.title="OSA Server"
+LABEL org.opencontainers.image.description="Open Science Archive reference implementation"
+LABEL org.opencontainers.image.source="https://github.com/opensciencearchive/server"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${OSA_VERSION}"
+LABEL org.opencontainers.image.revision="${OSA_REVISION}"
+
 # Install curl for health checks
 RUN apt-get update && apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*

--- a/server/osa/domain/deposition/service/convention.py
+++ b/server/osa/domain/deposition/service/convention.py
@@ -25,8 +25,8 @@ from osa.domain.shared.service import Service
 
 class ConventionService(Service):
     convention_repo: ConventionRepository
-    schema_service: SchemaService
-    metadata_service: MetadataService
+    schema_service: SchemaService  # TODO: replace with a port?
+    metadata_service: MetadataService  # TODO: replace with a port?
     outbox: Outbox
     node_domain: Domain
 

--- a/server/osa/domain/ingest/command/start_ingest.py
+++ b/server/osa/domain/ingest/command/start_ingest.py
@@ -27,6 +27,7 @@ class StartIngestHandler(CommandHandler[StartIngest, IngestRunCreated]):
 
     __auth__ = at_least(Role.ADMIN)
 
+    # TODO: do we ned these imports to be lazy?
     from osa.domain.auth.model.principal import Principal
     from osa.domain.ingest.service.ingest import IngestService
 
@@ -34,7 +35,7 @@ class StartIngestHandler(CommandHandler[StartIngest, IngestRunCreated]):
     service: IngestService
 
     async def run(self, cmd: StartIngest) -> IngestRunCreated:
-        from osa.domain.shared.model.srn import Domain
+        from osa.domain.shared.model.srn import Domain  # TODO: lazy needed?
 
         ingest_run = await self.service.start_ingest(
             convention_srn=cmd.convention_srn,
@@ -43,7 +44,7 @@ class StartIngestHandler(CommandHandler[StartIngest, IngestRunCreated]):
         )
 
         node_domain: Domain = self.service.node_domain
-        srn = f"urn:osa:{node_domain.root}:ing:{ingest_run.id}"
+        srn = f"urn:osa:{node_domain.root}:ing:{ingest_run.id}"  # TODO: use SRN class to build
 
         return IngestRunCreated(
             srn=srn,

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -27,7 +27,7 @@ class IngestService(Service):
 
     async def start_ingest(
         self,
-        convention_srn: str,
+        convention_srn: str,  # TODO: use convention ID instead of SRN
         batch_size: int = 1000,
         limit: int | None = None,
     ) -> IngestRun:

--- a/server/osa/infrastructure/oci/ingester_runner.py
+++ b/server/osa/infrastructure/oci/ingester_runner.py
@@ -193,8 +193,12 @@ class OciIngesterRunner(IngesterRunner):
             if container is not None:
                 try:
                     await container.delete(force=True)
-                except Exception:
-                    pass
+                except Exception as e:
+                    log.warning(
+                        "failed to delete ingester container {container_id}: {error}",
+                        container_id=container.id,
+                        error=str(e),
+                    )
 
     def _host_path(self, container_path: Path) -> str:
         """Translate a container-internal path to a host path for bind mounts.

--- a/server/osa/infrastructure/oci/runner.py
+++ b/server/osa/infrastructure/oci/runner.py
@@ -226,8 +226,12 @@ class OciHookRunner(HookRunner):
             if container is not None:
                 try:
                     await container.delete(force=True)
-                except Exception:
-                    pass
+                except Exception as e:
+                    log.warning(
+                        "failed to delete hook container {container_id}: {error}",
+                        container_id=container.id,
+                        error=str(e),
+                    )
 
     def _host_path(self, container_path: Path) -> str:
         """Translate a container-internal path to a host path for bind mounts."""

--- a/server/osa/infrastructure/persistence/metadata_store.py
+++ b/server/osa/infrastructure/persistence/metadata_store.py
@@ -205,7 +205,7 @@ class PostgresMetadataStore(MetadataStore):
     async def insert_many(
         self,
         schema_id: SchemaId,
-        rows: list[tuple[RecordSRN, dict[str, Any]]],
+        rows: list[tuple[RecordSRN, dict[str, Any]]],  # TODO: use a Pydantic object?
     ) -> None:
         if not rows:
             return
@@ -224,7 +224,7 @@ class PostgresMetadataStore(MetadataStore):
             )
             .mappings()
             .first()
-        )
+        )  # TODO: parse into Pydantic object?
 
         if catalog_row is None:
             raise ValidationError(

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osa"
-version = "0.1.0"
+version = "0.0.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1006,7 +1006,7 @@ wheels = [
 
 [[package]]
 name = "osa"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
Closes #131.

This PR bundles the socket-proxy fix with the first cut of release infrastructure, so the resulting `v0.0.1` semver-tagged image carries the proxy fix from day one.

## Part 1 — Docker socket proxy (the original fix)

The published OSA image runs as `appuser`, which can't read the host's `/var/run/docker.sock` (root:docker 0660). Direct socket mount fails with EACCES on every ingester/validator spawn. Fix is purely deploy-layer: add a `tecnativa/docker-socket-proxy` sidecar (`v0.4.2`) that holds the socket bind mount and exposes a locked-down Docker API (CONTAINERS, IMAGES, POST only) over TCP. The OSA server reaches it via `DOCKER_HOST`, no longer mounts the socket, no longer needs filesystem access to the daemon.

The proxy lives on an internal-only Docker network with no external egress. The compose v2 environment-map merge means dev (`-f docker-compose.dev.yml`) inherits `DOCKER_HOST` and the proxy dependency without further changes.

The server's `depends_on` waits for `service_healthy` on the proxy (added on Greptile's review), so a fast worker spawning an ingest at cold-start can't race the proxy. Verified live — server boot blocks on `docker-socket-proxy Healthy`.

Verified end-to-end against the pilot using the published `sha-a747fc1` image: ingester containers spawn cleanly, "Cannot connect to Docker Engine" log line is gone.

## Part 2 — Release infrastructure

Sets up the path for cutting GitHub Releases that produce semver-tagged images at `ghcr.io/opensciencearchive/osa:vX.Y.Z`. The `release: published` trigger in `image.yml` already existed; this adds the surrounding polish so the resulting images are auditable and the process is documented.

- **`server/Dockerfile`** gains `OSA_VERSION` + `OSA_REVISION` build args plus six OCI image labels (title, description, source, licenses, version, revision). Verified locally: `docker inspect` shows all labels populated.
- **`.github/workflows/image.yml`** passes `OSA_VERSION` (release tag or commit SHA) and `OSA_REVISION` (full SHA) as build args.
- **`server/pyproject.toml`** bumps `0.1.0` → `0.0.1` to match the chosen first release version. No registry tag exists for `0.1.0`, so safe to align.
- **`RELEASING.md`** documents the flow.

No floating `:latest` / `:vX` / `:vX.Y` tags — OSA is consumed via compose files with pinned `OSA_IMAGE_TAG`, not ad-hoc `docker pull`.

## After merge

Cut `v0.0.1`:

```sh
gh release create v0.0.1 --target main --title "v0.0.1" \
  --notes "First tagged release. Includes the Docker socket proxy fix (#131) and release infrastructure setup."
```

Then bump pilot `.env` to `OSA_IMAGE_TAG=v0.0.1` and verify ingest end-to-end against the semver-pinned image.

## Verification

- `docker compose -f deploy/docker-compose.yml config` and the same with `-f docker-compose.dev.yml` overlaid: server has `DOCKER_HOST`, no socket mount, both files inherit the proxy via env-map merge — no dev-side changes needed.
- `ruff check` clean, `pytest tests/unit` 1072 passed.
- Local `docker build --build-arg OSA_VERSION=v0.0.1-test ...`: all six OCI labels populated correctly under `docker inspect`.
- End-to-end smoke test against published image via pilot (see Part 1 above).

## Notes for reviewers

- Branch also contains a pre-existing unrelated commit (`baf5fe4` — TODO comments on four server files) authored before I started. Happy to drop it via interactive rebase if you'd rather land cleanly; let me know.

## Follow-ups (separate issues)

- Productize as `osa init` / `osa start` CLI flow — tracked at opensciencearchive/osa-py#5.
- Dev compose's `target: builder` shortcut (the reason this bug was invisible in dev) — out of scope here, worth a separate issue.
- `CLAUDE.md` opens with "Open Scientific Archive" — should be "Open Science Archive"; one-line fix worth a separate small PR.