### PR TITLE
chore: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       server: ${{ steps.filter.outputs.server }}
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -68,7 +68,7 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -96,7 +96,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -137,7 +137,7 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -176,7 +176,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -227,7 +227,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -256,7 +256,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -17,11 +17,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: server
           push: true


### PR DESCRIPTION
GHA warning surfaced after #132 merged: our action versions are pinned to majors that still run on Node 20. GitHub force-migrates to Node 24 on **2026-06-16** (about two weeks) and removes Node 20 entirely on **2026-09-16**. Getting ahead of it now.

## Changes

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v6` | `@v7` |

8 occurrences of `checkout` in `ci.yml`, plus 1 each of all four in `image.yml`.

## Why majors and not the env-var opt-in

GitHub offers `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` as a temporary opt-in, but the cleaner answer is to use the upstream actions' Node 24 releases. They all have current majors that ship Node 24 natively — no transitional flag needed, and we drop a future cleanup item.

## Risk

Low. Our usage of all four is parameter-free or near-parameter-free (`context: server`, `cache-from: type=gha`, etc.). Major bumps in these actions are typically driven by the Node runtime change, not API breaks for the common path.

The first CI run on this PR will exercise everything end-to-end. If `checkout@v6` does anything surprising (e.g. fetch-depth defaults change), the build will fail visibly rather than silently.

## Reference

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/