### PR TITLE
feat: serve auto-generated agent skill from each node

### DIFF
--- a/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
+++ b/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
@@ -35,6 +35,7 @@ def upgrade() -> None:
         sa.Column("file_requirements", sa.JSON(), nullable=False),
         sa.Column("hooks", sa.JSON(), nullable=False),
         sa.Column("source", sa.JSON(), nullable=True),
+        sa.Column("docs", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/server/osa/application/api/rest/app.py
+++ b/server/osa/application/api/rest/app.py
@@ -27,6 +27,7 @@ from osa.application.api.v1.routes import (
     validation,
 )
 from osa.application.api.v1.routes import data as data_routes
+from osa.application.api.rest import skill as skill_routes
 from osa.application.api.v1.routes.data._limiter import limiter
 from osa.application.di import create_container
 from osa.config import DEV_JWT_SECRET, Config
@@ -204,6 +205,10 @@ def create_app(
     app_instance.include_router(ingestions.router, prefix="/api/v1")
     app_instance.include_router(validation.router, prefix="/api/v1")
     app_instance.include_router(data_routes.router, prefix="/api/v1")
+
+    # Unversioned root surface — GET / and GET /SKILL.md (#151). Included
+    # after the /api/v1 routers so nothing shadows the API prefix.
+    app_instance.include_router(skill_routes.router)
 
     # POST /data/* rate limiting (slowapi). The shared limiter is attached to
     # app state and its 429 handler registered; GET routes are not limited.

--- a/server/osa/application/api/rest/skill.py
+++ b/server/osa/application/api/rest/skill.py
@@ -1,0 +1,39 @@
+"""Unversioned root routes — the agent bootstrap surface (#151).
+
+Only ``GET /`` (root discovery JSON) and ``GET /SKILL.md`` live at the domain
+root (research §2); the per-schema reference doc is a ``.md`` representation
+on the versioned data surface. Thin routes: handler → JSON / markdown
+Response — no business logic here.
+"""
+
+from __future__ import annotations
+
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, Request, Response
+
+from osa.domain.data.model.skill import RootDiscovery
+from osa.domain.data.query.skill import (
+    GetRootDiscovery,
+    GetRootDiscoveryHandler,
+    GetSkillDocument,
+    GetSkillDocumentHandler,
+)
+
+MARKDOWN_MEDIA_TYPE = "text/markdown; charset=utf-8"
+
+router = APIRouter(tags=["skill"], route_class=DishkaRoute)
+
+
+@router.get("/", operation_id="skill_get_root_discovery", response_model=RootDiscovery)
+async def get_root_discovery(
+    request: Request, handler: FromDishka[GetRootDiscoveryHandler]
+) -> RootDiscovery:
+    """Root discovery document: node identity + pointers for agents."""
+    return await handler.run(GetRootDiscovery(openapi_path=request.app.openapi_url or ""))
+
+
+@router.get("/SKILL.md", operation_id="skill_get_skill_document")
+async def get_skill_document(handler: FromDishka[GetSkillDocumentHandler]) -> Response:
+    """Generated agent-skill index (markdown), rendered from the live catalog."""
+    content = await handler.run(GetSkillDocument())
+    return Response(content=content, media_type=MARKDOWN_MEDIA_TYPE)

--- a/server/osa/application/api/rest/skill.py
+++ b/server/osa/application/api/rest/skill.py
@@ -18,6 +18,7 @@ from osa.domain.data.query.skill import (
     GetSkillDocument,
     GetSkillDocumentHandler,
 )
+from osa.domain.shared.error import ConfigurationError
 
 MARKDOWN_MEDIA_TYPE = "text/markdown; charset=utf-8"
 
@@ -29,7 +30,12 @@ async def get_root_discovery(
     request: Request, handler: FromDishka[GetRootDiscoveryHandler]
 ) -> RootDiscovery:
     """Root discovery document: node identity + pointers for agents."""
-    return await handler.run(GetRootDiscovery(openapi_path=request.app.openapi_url or ""))
+    openapi_path = request.app.openapi_url
+    if openapi_path is None:
+        # The discovery document must not advertise a dead openapi_url; a node
+        # with OpenAPI disabled is misconfigured for the agent surface.
+        raise ConfigurationError("Root discovery requires the OpenAPI schema to be enabled")
+    return await handler.run(GetRootDiscovery(openapi_path=openapi_path))
 
 
 @router.get("/SKILL.md", operation_id="skill_get_skill_document")

--- a/server/osa/application/api/v1/routes/data/__init__.py
+++ b/server/osa/application/api/v1/routes/data/__init__.py
@@ -17,6 +17,7 @@ from osa.application.api.v1.routes.data import (
     features_table,
     records,
     records_table,
+    reference,
 )
 from osa.domain.data.model.catalog import NodeCatalog
 
@@ -39,9 +40,11 @@ tables_router = APIRouter(route_class=DishkaRoute)
 records_table.register(tables_router)
 features_table.register(tables_router)
 
-# Order matters: literal ``/records/{id}`` and the ``/{schema}/records*`` table
-# routes must precede the manifest's ``/{schema}`` catch-all so a record fetch
-# or table read isn't captured as a schema manifest lookup.
+# Order matters: literal ``/records/{id}``, the ``/{schema}/records*`` table
+# routes, and the ``/{schema}.md`` reference doc must precede the manifest's
+# ``/{schema}`` catch-all so a record fetch, table read, or reference render
+# isn't captured as a schema manifest lookup (longest-suffix-first, #151).
 router.include_router(records.router)
 router.include_router(tables_router)
+router.include_router(reference.router)
 router.include_router(catalog.manifest_router)

--- a/server/osa/application/api/v1/routes/data/catalog.py
+++ b/server/osa/application/api/v1/routes/data/catalog.py
@@ -32,7 +32,11 @@ async def get_node_catalog(handler: FromDishka[GetNodeCatalogHandler]) -> NodeCa
 
 
 @manifest_router.get(
-    "/{schema}", operation_id="data_get_schema_manifest", response_model=SchemaManifest
+    "/{schema}",
+    operation_id="data_get_schema_manifest",
+    response_model=SchemaManifest,
+    # Absent metadata is omitted, never emitted as null keys (FR-019/AS-2).
+    response_model_exclude_none=True,
 )
 async def get_schema_manifest(
     schema: str, handler: FromDishka[GetSchemaManifestHandler]

--- a/server/osa/application/api/v1/routes/data/reference.py
+++ b/server/osa/application/api/v1/routes/data/reference.py
@@ -1,0 +1,27 @@
+"""Schema reference route — ``GET /data/{schema}.md`` (#151).
+
+The markdown representation of the schema resource, following the data
+surface's suffix convention (``.csv``/``.csv.gz`` precedent). Registered
+before the ``/{schema}`` manifest catch-all (longest-suffix-first);
+resolution reuses ``resolve_schema`` (unknown/reserved ids → 404).
+"""
+
+from __future__ import annotations
+
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, Response
+
+from osa.domain.data.query.skill import GetSchemaReference, GetSchemaReferenceHandler
+
+MARKDOWN_MEDIA_TYPE = "text/markdown; charset=utf-8"
+
+router = APIRouter(route_class=DishkaRoute)
+
+
+@router.get("/{schema}.md", operation_id="data_get_schema_reference")
+async def get_schema_reference(
+    schema: str, handler: FromDishka[GetSchemaReferenceHandler]
+) -> Response:
+    """Reference doc for a schema (`<id>` or `<id>@<semver>`), as markdown."""
+    content = await handler.run(GetSchemaReference(schema=schema))
+    return Response(content=content, media_type=MARKDOWN_MEDIA_TYPE)

--- a/server/osa/domain/data/model/manifest.py
+++ b/server/osa/domain/data/model/manifest.py
@@ -22,6 +22,9 @@ class FieldSpec(BaseModel):
     type: FieldType
     ontology_id: str | None = None  # required iff type == TERM
     ontology_version: str | None = None  # required iff type == TERM
+    description: str | None = None
+    unit: str | None = None  # hoisted from NumberConstraints.unit
+    examples: list[str] | None = None
 
 
 class ColumnSpec(BaseModel):
@@ -29,6 +32,9 @@ class ColumnSpec(BaseModel):
 
     name: str
     type: FieldType
+    format: str | None = None
+    description: str | None = None
+    unit: str | None = None
 
 
 # Implicit columns present on every records-table response, in wire order,
@@ -67,6 +73,7 @@ class SchemaManifest(BaseModel):
     id: str  # short schema id, e.g. "compound"
     version: str  # SemVer, e.g. "1.0.0"
     srn: str  # full schema SRN
+    title: str | None = None
     fields: list[FieldSpec]
     table_resources: list[TableResource]
 

--- a/server/osa/domain/data/model/manifest.py
+++ b/server/osa/domain/data/model/manifest.py
@@ -73,7 +73,7 @@ class SchemaManifest(BaseModel):
     id: str  # short schema id, e.g. "compound"
     version: str  # SemVer, e.g. "1.0.0"
     srn: str  # full schema SRN
-    title: str | None = None
+    title: str  # schemas.title is NOT NULL — every schema has one
     fields: list[FieldSpec]
     table_resources: list[TableResource]
 

--- a/server/osa/domain/data/model/skill.py
+++ b/server/osa/domain/data/model/skill.py
@@ -68,9 +68,13 @@ class SampleValue(BaseModel):
 
 
 class DatasetEntry(BaseModel):
-    """One row of the SKILL.md datasets table."""
+    """One row of the SKILL.md datasets table.
 
-    schema_id: str  # bare short id, e.g. "alloy-tests" (reference link target)
+    ``schema_ref`` is the fully-qualified ``<id>@<version>`` — it is both the
+    row label and the reference-link target, so the link always resolves to
+    exactly the documented version (a bare id would resolve to *latest*).
+    """
+
     schema_ref: str  # "<id>@<version>"
     title: str
     row_count: int

--- a/server/osa/domain/data/model/skill.py
+++ b/server/osa/domain/data/model/skill.py
@@ -40,11 +40,16 @@ class ExampleDoc(BaseModel):
 
 
 class AuthorDocs(BaseModel):
-    """Author semantics for one schema, projected from its owning convention."""
+    """Author semantics for one schema, projected from its owning convention.
+
+    ``examples`` is required — the persisted ``ConventionDocs`` guarantees ≥1
+    worked example, and this read DTO must not re-admit the state the write
+    side made unrepresentable.
+    """
 
     purpose: str
     example_questions: list[str] = []
-    examples: list[ExampleDoc] = []
+    examples: list[ExampleDoc]
     when_not_to_use: str | None = None
     see_also: list[str] | None = None
 
@@ -67,5 +72,5 @@ class DatasetEntry(BaseModel):
 
     schema_id: str  # bare short id, e.g. "alloy-tests" (reference link target)
     schema_ref: str  # "<id>@<version>"
-    title: str | None
+    title: str
     row_count: int

--- a/server/osa/domain/data/model/skill.py
+++ b/server/osa/domain/data/model/skill.py
@@ -1,0 +1,71 @@
+"""Read-side DTOs for the skill surface (#151).
+
+These are projections consumed by the skill generator/renderer. ``AuthorDocs``
+mirrors the deposition-owned ``ConventionDocs`` shape but is a distinct read
+DTO — the ``data`` domain never imports ``deposition`` internals; the read
+store validates the persisted ``conventions.docs`` JSONB into this shape.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class NodeIdentity(BaseModel):
+    """Node identity block of the root discovery document (from ``Config``)."""
+
+    name: str
+    domain: str
+    description: str
+    osa_version: str
+
+
+class RootDiscovery(BaseModel):
+    """The ``GET /`` response body (contracts/root-discovery.md)."""
+
+    node: NodeIdentity
+    skill_url: str
+    reference_base: str
+    data_url: str
+    openapi_url: str
+    schemas: list[str]  # "<id>@<version>" at latest published version
+
+
+class ExampleDoc(BaseModel):
+    """A worked example, rendered verbatim (FR-018)."""
+
+    question: str
+    query: str
+    interpretation: str
+
+
+class AuthorDocs(BaseModel):
+    """Author semantics for one schema, projected from its owning convention."""
+
+    purpose: str
+    example_questions: list[str] = []
+    examples: list[ExampleDoc] = []
+    when_not_to_use: str | None = None
+    see_also: list[str] | None = None
+
+    def trigger_questions(self) -> list[str]:
+        """Distinct trigger-question union, in first-seen order (FR-002)."""
+        seen: dict[str, None] = {}
+        for q in [*self.example_questions, *(e.question for e in self.examples)]:
+            seen.setdefault(q.strip())
+        return list(seen)
+
+
+class SampleValue(BaseModel):
+    """One sampled non-null value for example templating (research §9)."""
+
+    value: str | int | float | bool
+
+
+class DatasetEntry(BaseModel):
+    """One row of the SKILL.md datasets table."""
+
+    schema_id: str  # bare short id, e.g. "alloy-tests" (reference link target)
+    schema_ref: str  # "<id>@<version>"
+    title: str | None
+    row_count: int

--- a/server/osa/domain/data/port/data_read_store.py
+++ b/server/osa/domain/data/port/data_read_store.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from osa.domain.data.model.manifest import SchemaManifest
     from osa.domain.data.model.query_plan import QueryPlan
     from osa.domain.data.model.record_summary import RecordSummary
+    from osa.domain.data.model.skill import AuthorDocs, SampleValue
     from osa.domain.shared.model.ids import RecordId
     from osa.domain.shared.model.srn import SchemaId
 
@@ -54,4 +55,23 @@ class DataCatalogReadStore(Protocol):
 
     async def get_latest_schema_id(self, schema_short_id: str) -> "SchemaId | None":
         """Resolve a bare schema id to its latest published version. ``None`` if unknown."""
+        ...
+
+    async def get_author_docs(self, schema_id: str, version: str) -> "AuthorDocs | None":
+        """Author docs from the schema's owning convention (latest deploy wins).
+
+        Every convention carries docs (``NOT NULL``), so ``None`` means only
+        "no owning convention exists" — the renderer's sole degradation signal
+        (FR-023).
+        """
+        ...
+
+    async def sample_value(
+        self, schema_id: "SchemaId", table: str, column: str
+    ) -> "SampleValue | None":
+        """One non-null value from a column for example templating (research §9).
+
+        ``table`` is ``"records"`` (scoped to the schema's records) or a
+        feature-table name. ``None`` when the column has no non-null values.
+        """
         ...

--- a/server/osa/domain/data/port/data_read_store.py
+++ b/server/osa/domain/data/port/data_read_store.py
@@ -57,7 +57,7 @@ class DataCatalogReadStore(Protocol):
         """Resolve a bare schema id to its latest published version. ``None`` if unknown."""
         ...
 
-    async def get_author_docs(self, schema_id: str, version: str) -> "AuthorDocs | None":
+    async def get_author_docs(self, schema_id: "SchemaId") -> "AuthorDocs | None":
         """Author docs from the schema's owning convention (latest deploy wins).
 
         Every convention carries docs (``NOT NULL``), so ``None`` means only

--- a/server/osa/domain/data/query/skill.py
+++ b/server/osa/domain/data/query/skill.py
@@ -1,0 +1,50 @@
+"""Skill-surface query handlers — root discovery, SKILL.md, schema reference (#151).
+
+All public (``__auth__ = public()``): the surface documents published data
+only (FR-004) and exists precisely so unauthenticated agents can bootstrap.
+"""
+
+from __future__ import annotations
+
+from osa.domain.data.model.skill import RootDiscovery
+from osa.domain.data.service.skill_generator import SkillGeneratorService
+from osa.domain.shared.authorization.gate import public
+from osa.domain.shared.query import Query, QueryHandler
+
+
+class GetRootDiscovery(Query):
+    # The app's actual configured OpenAPI path (research §7) — the route knows
+    # it; the domain must not import the FastAPI app.
+    openapi_path: str
+
+
+class GetRootDiscoveryHandler(QueryHandler[GetRootDiscovery, RootDiscovery]):
+    __auth__ = public()
+    generator: SkillGeneratorService
+
+    async def run(self, cmd: GetRootDiscovery) -> RootDiscovery:
+        return await self.generator.root_discovery(cmd.openapi_path)
+
+
+class GetSkillDocument(Query):
+    pass
+
+
+class GetSkillDocumentHandler(QueryHandler[GetSkillDocument, str]):
+    __auth__ = public()
+    generator: SkillGeneratorService
+
+    async def run(self, cmd: GetSkillDocument) -> str:
+        return await self.generator.skill_document()
+
+
+class GetSchemaReference(Query):
+    schema: str  # URL segment: ``<id>`` (latest) or ``<id>@<semver>``
+
+
+class GetSchemaReferenceHandler(QueryHandler[GetSchemaReference, str]):
+    __auth__ = public()
+    generator: SkillGeneratorService
+
+    async def run(self, cmd: GetSchemaReference) -> str:
+        return await self.generator.schema_reference(cmd.schema)

--- a/server/osa/domain/data/service/skill_generator.py
+++ b/server/osa/domain/data/service/skill_generator.py
@@ -68,7 +68,7 @@ class SkillGeneratorService(Service):
                     row_count=records.row_count,
                 )
             )
-            author_docs = await self.read_store.get_author_docs(entry.id, entry.version)
+            author_docs = await self.read_store.get_author_docs(schema_id)
             if author_docs is not None:
                 docs.append(author_docs)
         return self.renderer.render_skill(
@@ -83,7 +83,7 @@ class SkillGeneratorService(Service):
         the schema resource). Unknown/reserved ids 404 via ``resolve_schema``."""
         schema_id = await self.catalog_service.resolve_schema(schema)
         manifest = await self.catalog_service.get_schema_manifest(schema_id)
-        docs = await self.read_store.get_author_docs(schema_id.id.root, schema_id.version.root)
+        docs = await self.read_store.get_author_docs(schema_id)
         sample_field = self.renderer.filter_example_field(manifest)
         sample: SampleValue | None = None
         if sample_field is not None:

--- a/server/osa/domain/data/service/skill_generator.py
+++ b/server/osa/domain/data/service/skill_generator.py
@@ -1,0 +1,97 @@
+"""SkillGeneratorService — assembles the skill-surface documents (#151).
+
+Composes ``Config`` (node identity), the catalog/manifest reads (live row
+counts — FR-005, no cache), author docs, and value samples, and feeds the
+pure :class:`SkillRenderer`. All I/O goes through the data read-store port.
+"""
+
+from __future__ import annotations
+
+from osa.config import Config
+from osa.domain.data.model.skill import (
+    DatasetEntry,
+    NodeIdentity,
+    RootDiscovery,
+    SampleValue,
+)
+from osa.domain.data.port.data_read_store import DataCatalogReadStore
+from osa.domain.data.service.data_catalog import DataCatalogService
+from osa.domain.data.service.skill_renderer import SkillRenderer
+from osa.domain.shared.service import Service
+
+
+class SkillGeneratorService(Service):
+    catalog_service: DataCatalogService
+    read_store: DataCatalogReadStore
+    renderer: SkillRenderer
+    config: Config
+
+    def _node_identity(self) -> NodeIdentity:
+        return NodeIdentity(
+            name=self.config.name,
+            domain=self.config.domain,
+            description=self.config.description,
+            osa_version=self.config.version,
+        )
+
+    def _base_url(self) -> str:
+        return self.config.base_url.rstrip("/")
+
+    async def root_discovery(self, openapi_path: str) -> RootDiscovery:
+        """The ``GET /`` document. ``openapi_path`` is the app's actual
+        configured OpenAPI path (research §7) — passed in by the route."""
+        base = self._base_url()
+        catalog = await self.catalog_service.get_node_catalog()
+        return RootDiscovery(
+            node=self._node_identity(),
+            skill_url=f"{base}/SKILL.md",
+            reference_base=f"{base}/api/v1/data/",
+            data_url=f"{base}/api/v1/data",
+            openapi_url=f"{base}{openapi_path}",
+            schemas=[f"{entry.id}@{entry.version}" for entry in catalog.schemas],
+        )
+
+    async def skill_document(self) -> str:
+        """Render ``SKILL.md`` from the live catalog (FR-005)."""
+        catalog = await self.catalog_service.get_node_catalog()
+        datasets: list[DatasetEntry] = []
+        docs = []
+        for entry in catalog.schemas:
+            schema_id = await self.catalog_service.resolve_schema(f"{entry.id}@{entry.version}")
+            manifest = await self.catalog_service.get_schema_manifest(schema_id)
+            records = next(t for t in manifest.table_resources if t.name == "records")
+            datasets.append(
+                DatasetEntry(
+                    schema_id=entry.id,
+                    schema_ref=f"{entry.id}@{entry.version}",
+                    title=manifest.title,
+                    row_count=records.row_count,
+                )
+            )
+            author_docs = await self.read_store.get_author_docs(entry.id, entry.version)
+            if author_docs is not None:
+                docs.append(author_docs)
+        return self.renderer.render_skill(
+            node=self._node_identity(),
+            base_url=self._base_url(),
+            datasets=datasets,
+            docs=docs,
+        )
+
+    async def schema_reference(self, schema: str) -> str:
+        """Render the reference doc for one schema (markdown representation of
+        the schema resource). Unknown/reserved ids 404 via ``resolve_schema``."""
+        schema_id = await self.catalog_service.resolve_schema(schema)
+        manifest = await self.catalog_service.get_schema_manifest(schema_id)
+        docs = await self.read_store.get_author_docs(schema_id.id.root, schema_id.version.root)
+        sample_field = self.renderer.filter_example_field(manifest)
+        sample: SampleValue | None = None
+        if sample_field is not None:
+            sample = await self.read_store.sample_value(schema_id, "records", sample_field)
+        return self.renderer.render_reference(
+            manifest=manifest,
+            docs=docs,
+            base_url=self._base_url(),
+            sample_field=sample_field,
+            sample=sample,
+        )

--- a/server/osa/domain/data/service/skill_generator.py
+++ b/server/osa/domain/data/service/skill_generator.py
@@ -62,7 +62,6 @@ class SkillGeneratorService(Service):
             records = next(t for t in manifest.table_resources if t.name == "records")
             datasets.append(
                 DatasetEntry(
-                    schema_id=entry.id,
                     schema_ref=f"{entry.id}@{entry.version}",
                     title=manifest.title,
                     row_count=records.row_count,

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -44,8 +44,10 @@ def _one_line(text: str) -> str:
     return " ".join(text.split())
 
 
-def _reference_path(schema_id: str) -> str:
-    return quote(f"api/v1/data/{schema_id}.md", safe="/")
+def _reference_path(schema_ref: str) -> str:
+    # `@` stays literal: it is valid in a path segment and the versioned ref
+    # must remain copy-pasteable.
+    return quote(f"api/v1/data/{schema_ref}.md", safe="/@")
 
 
 class SkillRenderer(Service):
@@ -85,7 +87,7 @@ class SkillRenderer(Service):
             for ds in datasets:
                 lines.append(
                     f"| {ds.schema_ref} | {ds.title} | {ds.row_count} "
-                    f"| {_reference_path(ds.schema_id)} |"
+                    f"| {_reference_path(ds.schema_ref)} |"
                 )
         else:
             lines.append("No datasets yet.")

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -1,0 +1,315 @@
+"""SkillRenderer — pure markdown rendering for the skill surface (#151).
+
+String in/out, no I/O (research §3): the generator assembles catalog data,
+author docs, and samples; this service turns them into the two documents —
+``SKILL.md`` and the per-schema reference. Exact output is pinned by unit
+tests, so every formatting decision lives here and nowhere else.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import quote
+
+from osa.domain.data.model.manifest import SchemaManifest, TableResource
+from osa.domain.data.model.query_plan import TableKind
+from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, NodeIdentity, SampleValue
+from osa.domain.shared.service import Service
+
+# A clearly-labeled stand-in used when no real value could be sampled
+# (empty column/table — FR-021/022); the example stays syntactically valid.
+PLACEHOLDER_VALUE = "REPLACE_WITH_A_REAL_VALUE"
+
+# Fixed documentation for the implicit records-table columns (wire order).
+_IMPLICIT_RECORD_DOCS: list[tuple[str, str, str]] = [
+    ("id", "text", "Record identifier (node-assigned, stable)"),
+    ("srn", "text", "Full record SRN — join key for feature tables"),
+    ("schema_id", "text", "Owning schema id"),
+    ("version", "number", "Record version"),
+    ("created_at", "date", "Publication timestamp"),
+]
+
+_IMPLICIT_RECORD_NAMES = {name for name, _, _ in _IMPLICIT_RECORD_DOCS}
+
+
+def sanitize_skill_name(domain: str) -> str:
+    """``osa-data-<domain>`` with every char outside [a-z0-9] mapped to ``-``,
+    runs collapsed (FR-006; research §8)."""
+    slug = re.sub(r"-+", "-", re.sub(r"[^a-z0-9]", "-", domain.lower())).strip("-")
+    return f"osa-data-{slug}"
+
+
+def _one_line(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _reference_path(schema_id: str) -> str:
+    return quote(f"api/v1/data/{schema_id}.md", safe="/")
+
+
+class SkillRenderer(Service):
+    """Pure markdown rendering — no ports, no I/O."""
+
+    # ------------------------------------------------------------------ #
+    # SKILL.md
+    # ------------------------------------------------------------------ #
+
+    def render_skill(
+        self,
+        *,
+        node: NodeIdentity,
+        base_url: str,
+        datasets: list[DatasetEntry],
+        docs: list[AuthorDocs],
+    ) -> str:
+        lines: list[str] = []
+        lines.append("---")
+        lines.append(f"name: {sanitize_skill_name(node.domain)}")
+        lines.append(f"description: {self._skill_description(node, docs)}")
+        lines.append("---")
+        lines.append("")
+        lines.append(f"# {node.name}")
+
+        for d in docs:
+            if d.purpose.strip():
+                lines.append("")
+                lines.append(_one_line(d.purpose))
+
+        lines.append("")
+        lines.append("## Datasets")
+        lines.append("")
+        if datasets:
+            lines.append("| Schema | Title | Records | Reference |")
+            lines.append("|---|---|---|---|")
+            for ds in datasets:
+                title = ds.title or ""
+                lines.append(
+                    f"| {ds.schema_ref} | {title} | {ds.row_count} "
+                    f"| {_reference_path(ds.schema_id)} |"
+                )
+        else:
+            lines.append("No datasets yet.")
+
+        lines.append("")
+        lines.append("## Access")
+        lines.append("")
+        lines.append(f"- Bulk:   GET  {base_url}/api/v1/data/<schema>/records.csv.gz")
+        lines.append(
+            f"- Filter: POST {base_url}/api/v1/data/<schema>/records "
+            f"(FilterExpr body — use for large tables)"
+        )
+        lines.append(f"- One:    GET  {base_url}/api/v1/data/records/<id>")
+
+        when_not = [d.when_not_to_use for d in docs if d.when_not_to_use]
+        if when_not:
+            lines.append("")
+            lines.append("## When not to use")
+            for text in when_not:
+                lines.append("")
+                lines.append(_one_line(text))
+
+        see_also = [entry for d in docs if d.see_also for entry in d.see_also]
+        if see_also:
+            lines.append("")
+            lines.append("## See also")
+            lines.append("")
+            for entry in see_also:
+                lines.append(f"- {entry}")
+
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def _skill_description(node: NodeIdentity, docs: list[AuthorDocs]) -> str:
+        questions: dict[str, None] = {}
+        for d in docs:
+            for q in d.trigger_questions():
+                questions.setdefault(q)
+        description = _one_line(node.description)
+        if questions:
+            description += " Use when answering questions like: " + " ".join(questions)
+        return description
+
+    # ------------------------------------------------------------------ #
+    # Reference document
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def filter_example_field(manifest: SchemaManifest) -> str | None:
+        """The field templated into the FilterExpr example — the first declared
+        metadata field (research §9). ``None`` when the schema has no fields."""
+        return manifest.fields[0].name if manifest.fields else None
+
+    def render_reference(
+        self,
+        *,
+        manifest: SchemaManifest,
+        docs: AuthorDocs | None,
+        base_url: str,
+        sample_field: str | None,
+        sample: SampleValue | None,
+    ) -> str:
+        schema_ref = f"{manifest.id}@{manifest.version}"
+        features = [t for t in manifest.table_resources if t.kind == TableKind.FEATURE]
+
+        lines: list[str] = []
+        lines.append(f"# {manifest.title or manifest.id} ({schema_ref})")
+
+        if docs is not None:
+            lines.append("")
+            lines.append(_one_line(docs.purpose))
+        else:
+            lines.append("")
+            lines.append("> No author documentation exists for this dataset.")
+
+        lines.extend(self._records_table_section(manifest))
+
+        if features:
+            lines.append("")
+            lines.append("## Feature tables")
+            for feature in features:
+                lines.extend(self._feature_section(feature))
+
+        lines.extend(self._join_provenance_section(base_url, features))
+        lines.extend(
+            self._mechanical_examples(
+                manifest=manifest,
+                base_url=base_url,
+                features=features,
+                sample_field=sample_field,
+                sample=sample,
+            )
+        )
+
+        if docs is not None:
+            lines.extend(self._worked_examples(docs))
+            if docs.when_not_to_use:
+                lines.append("")
+                lines.append("## When not to use")
+                lines.append("")
+                lines.append(_one_line(docs.when_not_to_use))
+            if docs.see_also:
+                lines.append("")
+                lines.append("## See also")
+                lines.append("")
+                for entry in docs.see_also:
+                    lines.append(f"- {entry}")
+
+        return "\n".join(lines) + "\n"
+
+    def _records_table_section(self, manifest: SchemaManifest) -> list[str]:
+        lines = ["", "## Records table", ""]
+        lines.append("| Column | Type | Unit | Description | Ontology | Examples |")
+        lines.append("|---|---|---|---|---|---|")
+        for name, type_, description in _IMPLICIT_RECORD_DOCS:
+            lines.append(f"| {name} | {type_} |  | {description} |  |  |")
+        for f in manifest.fields:
+            if f.name in _IMPLICIT_RECORD_NAMES:
+                continue
+            ontology = (
+                f"{f.ontology_id}@{f.ontology_version}"
+                if f.ontology_id and f.ontology_version
+                else (f.ontology_id or "")
+            )
+            examples = ", ".join(f.examples) if f.examples else ""
+            lines.append(
+                f"| {f.name} | {f.type.value} | {f.unit or ''} | {f.description or ''} "
+                f"| {ontology} | {examples} |"
+            )
+        return lines
+
+    @staticmethod
+    def _feature_section(feature: TableResource) -> list[str]:
+        lines = ["", f"### {feature.name}", ""]
+        lines.append("| Column | Type | Format | Unit | Description |")
+        lines.append("|---|---|---|---|---|")
+        for c in feature.columns:
+            lines.append(
+                f"| {c.name} | {c.type.value} | {c.format or ''} | {c.unit or ''} "
+                f"| {c.description or ''} |"
+            )
+        return lines
+
+    @staticmethod
+    def _join_provenance_section(base_url: str, features: list[TableResource]) -> list[str]:
+        lines = ["", "## Join keys & provenance", ""]
+        if features:
+            lines.append(
+                "- Feature rows join to records on `record_srn` = `records.srn`; "
+                "single records also resolve by bare `records.id`."
+            )
+        else:
+            lines.append("- Single records resolve by bare `records.id` or full `records.srn`.")
+        lines.append(
+            "- Provenance: every feature row's `run_id` resolves to a `hook_run`, "
+            "which references the `hook_release` (image, digest, config, source_ref) "
+            "that produced it."
+        )
+        return lines
+
+    def _mechanical_examples(
+        self,
+        *,
+        manifest: SchemaManifest,
+        base_url: str,
+        features: list[TableResource],
+        sample_field: str | None,
+        sample: SampleValue | None,
+    ) -> list[str]:
+        data_base = f"{base_url}/api/v1/data"
+        lines = ["", "## Examples", ""]
+        n = 1
+        lines.append(f"{n}. Bulk dump (start here):")
+        lines.append("")
+        lines.append(f"   GET {data_base}/{manifest.id}/records.csv.gz")
+        if sample_field is not None:
+            n += 1
+            value = sample.value if sample is not None else PLACEHOLDER_VALUE
+            body = json.dumps(
+                {
+                    "filter": {
+                        "kind": "predicate",
+                        "field": f"metadata.{sample_field}",
+                        "op": "eq",
+                        "value": value,
+                    }
+                },
+                ensure_ascii=False,
+            )
+            lines.append("")
+            lines.append(f"{n}. Filtered query (FilterExpr POST — use for large tables):")
+            lines.append("")
+            lines.append(f"   POST {data_base}/{manifest.id}/records")
+            lines.append(f"   {body}")
+        if features:
+            n += 1
+            feature = features[0]
+            lines.append("")
+            lines.append(
+                f"{n}. Record ↔ feature join: fetch the feature table and join its "
+                f"`{feature.name}.record_srn` column to `records.srn`:"
+            )
+            lines.append("")
+            lines.append(f"   GET {data_base}/{manifest.id}/{feature.name}.csv.gz")
+        n += 1
+        lines.append("")
+        lines.append(f"{n}. Single record:")
+        lines.append("")
+        lines.append(f"   GET {data_base}/records/<id>")
+        return lines
+
+    @staticmethod
+    def _worked_examples(docs: AuthorDocs) -> list[str]:
+        if not docs.examples:
+            return []
+        lines = ["", "## Worked examples"]
+        for example in docs.examples:
+            lines.append("")
+            lines.append(f"### {example.question}")
+            lines.append("")
+            lines.append("```")
+            lines.append(example.query)  # verbatim — never rewritten (FR-018)
+            lines.append("```")
+            lines.append("")
+            lines.append(example.interpretation)
+        return lines

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -83,9 +83,8 @@ class SkillRenderer(Service):
             lines.append("| Schema | Title | Records | Reference |")
             lines.append("|---|---|---|---|")
             for ds in datasets:
-                title = ds.title or ""
                 lines.append(
-                    f"| {ds.schema_ref} | {title} | {ds.row_count} "
+                    f"| {ds.schema_ref} | {ds.title} | {ds.row_count} "
                     f"| {_reference_path(ds.schema_id)} |"
                 )
         else:
@@ -153,7 +152,7 @@ class SkillRenderer(Service):
         features = [t for t in manifest.table_resources if t.kind == TableKind.FEATURE]
 
         lines: list[str] = []
-        lines.append(f"# {manifest.title or manifest.id} ({schema_ref})")
+        lines.append(f"# {manifest.title} ({schema_ref})")
 
         if docs is not None:
             lines.append("")

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -256,11 +256,15 @@ class SkillRenderer(Service):
         sample: SampleValue | None,
     ) -> list[str]:
         data_base = f"{base_url}/api/v1/data"
+        # Fully-qualified <id>@<version>: the doc may have been requested at a
+        # pinned version, and a bare id resolves to *latest* — the examples must
+        # target exactly the schema version this document describes.
+        schema_ref = f"{manifest.id}@{manifest.version}"
         lines = ["", "## Examples", ""]
         n = 1
         lines.append(f"{n}. Bulk dump (start here):")
         lines.append("")
-        lines.append(f"   GET {data_base}/{manifest.id}/records.csv.gz")
+        lines.append(f"   GET {data_base}/{schema_ref}/records.csv.gz")
         if sample_field is not None:
             n += 1
             value = sample.value if sample is not None else PLACEHOLDER_VALUE
@@ -278,7 +282,7 @@ class SkillRenderer(Service):
             lines.append("")
             lines.append(f"{n}. Filtered query (FilterExpr POST — use for large tables):")
             lines.append("")
-            lines.append(f"   POST {data_base}/{manifest.id}/records")
+            lines.append(f"   POST {data_base}/{schema_ref}/records")
             lines.append(f"   {body}")
         if features:
             n += 1
@@ -289,7 +293,7 @@ class SkillRenderer(Service):
                 f"`{feature.name}.record_srn` column to `records.srn`:"
             )
             lines.append("")
-            lines.append(f"   GET {data_base}/{manifest.id}/{feature.name}.csv.gz")
+            lines.append(f"   GET {data_base}/{schema_ref}/{feature.name}.csv.gz")
         n += 1
         lines.append("")
         lines.append(f"{n}. Single record:")

--- a/server/osa/domain/data/util/di/provider.py
+++ b/server/osa/domain/data/util/di/provider.py
@@ -16,8 +16,15 @@ from osa.domain.data.query.read_table import (
     ReadFeatureTableHandler,
     ReadRecordsTableHandler,
 )
+from osa.domain.data.query.skill import (
+    GetRootDiscoveryHandler,
+    GetSchemaReferenceHandler,
+    GetSkillDocumentHandler,
+)
 from osa.domain.data.service.data_catalog import DataCatalogService
 from osa.domain.data.service.data_query import DataQueryService
+from osa.domain.data.service.skill_generator import SkillGeneratorService
+from osa.domain.data.service.skill_renderer import SkillRenderer
 from osa.util.di.base import Provider
 from osa.util.di.scope import Scope
 
@@ -33,8 +40,30 @@ class DataProvider(Provider):
     def get_data_catalog_service(self, read_store: DataCatalogReadStore) -> DataCatalogService:
         return DataCatalogService(read_store=read_store)
 
+    @provide(scope=Scope.APP)
+    def get_skill_renderer(self) -> SkillRenderer:
+        return SkillRenderer()
+
+    @provide(scope=Scope.UOW)
+    def get_skill_generator_service(
+        self,
+        catalog_service: DataCatalogService,
+        read_store: DataCatalogReadStore,
+        renderer: SkillRenderer,
+        config: Config,
+    ) -> SkillGeneratorService:
+        return SkillGeneratorService(
+            catalog_service=catalog_service,
+            read_store=read_store,
+            renderer=renderer,
+            config=config,
+        )
+
     read_records_table_handler = provide(ReadRecordsTableHandler, scope=Scope.UOW)
     read_feature_table_handler = provide(ReadFeatureTableHandler, scope=Scope.UOW)
     get_node_catalog_handler = provide(GetNodeCatalogHandler, scope=Scope.UOW)
     get_schema_manifest_handler = provide(GetSchemaManifestHandler, scope=Scope.UOW)
     get_data_record_handler = provide(GetDataRecordHandler, scope=Scope.UOW)
+    get_root_discovery_handler = provide(GetRootDiscoveryHandler, scope=Scope.UOW)
+    get_skill_document_handler = provide(GetSkillDocumentHandler, scope=Scope.UOW)
+    get_schema_reference_handler = provide(GetSchemaReferenceHandler, scope=Scope.UOW)

--- a/server/osa/domain/deposition/command/create_convention.py
+++ b/server/osa/domain/deposition/command/create_convention.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from osa.domain.auth.model.principal import Principal
 from osa.domain.deposition.model.deploy import HookDeploy
@@ -9,6 +9,7 @@ from osa.domain.deposition.model.docs import (
     MIN_DISTINCT_TRIGGER_QUESTIONS,
     ConventionDocs,
     Example,
+    NonBlankStr,
 )
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.deposition.service.convention import ConventionService
@@ -87,16 +88,9 @@ class ExamplePayload(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    question: str = Field(min_length=1)
-    query: str = Field(min_length=1)
-    interpretation: str = Field(min_length=1)
-
-    @field_validator("question", "query", "interpretation")
-    @classmethod
-    def _non_blank(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("must not be empty or whitespace-only")
-        return v
+    question: NonBlankStr
+    query: NonBlankStr
+    interpretation: NonBlankStr
 
     def to_vo(self) -> Example:
         return Example(question=self.question, query=self.query, interpretation=self.interpretation)
@@ -112,25 +106,11 @@ class ConventionDocsPayload(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    purpose: str = Field(min_length=1)
-    example_questions: list[str] = []
+    purpose: NonBlankStr
+    example_questions: list[NonBlankStr] = []
     examples: list[ExamplePayload] = Field(min_length=1)
     when_not_to_use: str | None = None
     see_also: list[str] | None = None
-
-    @field_validator("purpose")
-    @classmethod
-    def _purpose_non_blank(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("purpose must not be empty or whitespace-only")
-        return v
-
-    @field_validator("example_questions")
-    @classmethod
-    def _questions_non_blank(cls, v: list[str]) -> list[str]:
-        if any(not q.strip() for q in v):
-            raise ValueError("example_questions entries must not be empty")
-        return v
 
     @model_validator(mode="after")
     def _require_trigger_breadth(self) -> "ConventionDocsPayload":

--- a/server/osa/domain/deposition/command/create_convention.py
+++ b/server/osa/domain/deposition/command/create_convention.py
@@ -1,10 +1,15 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from osa.domain.auth.model.principal import Principal
 from osa.domain.deposition.model.deploy import HookDeploy
+from osa.domain.deposition.model.docs import (
+    MIN_DISTINCT_TRIGGER_QUESTIONS,
+    ConventionDocs,
+    Example,
+)
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.semantics.model.value import FieldDefinition
@@ -74,6 +79,81 @@ class DeployConventionHook(BaseModel):
         )
 
 
+class ExamplePayload(BaseModel):
+    """Edge mirror of the ``Example`` VO — a worked example, rendered verbatim.
+
+    ``query`` is opaque: never parsed, executed, or validated (FR-011).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    question: str = Field(min_length=1)
+    query: str = Field(min_length=1)
+    interpretation: str = Field(min_length=1)
+
+    @field_validator("question", "query", "interpretation")
+    @classmethod
+    def _non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be empty or whitespace-only")
+        return v
+
+    def to_vo(self) -> Example:
+        return Example(question=self.question, query=self.query, interpretation=self.interpretation)
+
+
+class ConventionDocsPayload(BaseModel):
+    """Edge mirror of the ``ConventionDocs`` VO (#151).
+
+    The mandatory-docs minimum is repeated here so violations surface as a 422
+    whose field-level errors name each gap, regardless of client (FR-015/016).
+    There is no bypass flag.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    purpose: str = Field(min_length=1)
+    example_questions: list[str] = []
+    examples: list[ExamplePayload] = Field(min_length=1)
+    when_not_to_use: str | None = None
+    see_also: list[str] | None = None
+
+    @field_validator("purpose")
+    @classmethod
+    def _purpose_non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("purpose must not be empty or whitespace-only")
+        return v
+
+    @field_validator("example_questions")
+    @classmethod
+    def _questions_non_blank(cls, v: list[str]) -> list[str]:
+        if any(not q.strip() for q in v):
+            raise ValueError("example_questions entries must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def _require_trigger_breadth(self) -> "ConventionDocsPayload":
+        distinct = {q.strip() for q in self.example_questions}
+        distinct |= {e.question.strip() for e in self.examples}
+        if len(distinct) < MIN_DISTINCT_TRIGGER_QUESTIONS:
+            raise ValueError(
+                f"need at least {MIN_DISTINCT_TRIGGER_QUESTIONS} distinct trigger "
+                f"questions across example_questions and worked-example questions, "
+                f"got {len(distinct)}"
+            )
+        return self
+
+    def to_vo(self) -> ConventionDocs:
+        return ConventionDocs(
+            purpose=self.purpose,
+            example_questions=self.example_questions,
+            examples=[e.to_vo() for e in self.examples],
+            when_not_to_use=self.when_not_to_use,
+            see_also=self.see_also,
+        )
+
+
 class DeployConvention(Command):
     """Bundled deploy: schema + hooks (+ first releases) + convention, atomically.
 
@@ -95,6 +175,8 @@ class DeployConvention(Command):
     schema_block: DeployConventionSchema = Field(alias="schema")
     hooks: list[DeployConventionHook] = []
     ingester: IngesterDefinition | None = None
+    # Author semantics — required; documentation is mandatory (#151, FR-015).
+    docs: ConventionDocsPayload
 
 
 class ConventionCreated(Result):
@@ -126,6 +208,7 @@ class DeployConventionHandler(CommandHandler[DeployConvention, ConventionCreated
             schema_fields=cmd.schema_block.fields,
             hooks=[h.to_deploy() for h in cmd.hooks],
             ingester=cmd.ingester,
+            docs=cmd.docs.to_vo(),
             built_by=built_by,
         )
         return ConventionCreated(

--- a/server/osa/domain/deposition/model/convention.py
+++ b/server/osa/domain/deposition/model/convention.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from osa.domain.deposition.model.docs import ConventionDocs
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.shared.model.aggregate import Aggregate
 from osa.domain.shared.model.hook import HookName
@@ -23,4 +24,6 @@ class Convention(Aggregate):
     file_requirements: FileRequirements
     hooks: list[HookName] = []
     ingester: IngesterDefinition | None = None
+    # Author semantics — required: there is no docs-less convention state (#151).
+    docs: ConventionDocs
     created_at: datetime

--- a/server/osa/domain/deposition/model/docs.py
+++ b/server/osa/domain/deposition/model/docs.py
@@ -11,19 +11,22 @@ at all (FR-013..016).
 
 from typing import Annotated
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import AfterValidator, Field, model_validator
 
 from osa.domain.shared.model.value import ValueObject
-
-NonEmptyStr = Annotated[str, Field(min_length=1)]
 
 MIN_DISTINCT_TRIGGER_QUESTIONS = 3
 
 
-def _require_stripped(value: str, field_name: str) -> str:
+def _require_non_blank(value: str) -> str:
     if not value.strip():
-        raise ValueError(f"{field_name} must not be empty or whitespace-only")
+        raise ValueError("must not be empty or whitespace-only")
     return value
+
+
+# Non-empty AND not whitespace-only; the ValidationError's ``loc`` names the
+# offending field, so the message itself stays field-agnostic.
+NonBlankStr = Annotated[str, Field(min_length=1), AfterValidator(_require_non_blank)]
 
 
 class Example(ValueObject):
@@ -33,38 +36,21 @@ class Example(ValueObject):
     verbatim into the reference doc.
     """
 
-    question: NonEmptyStr
-    query: NonEmptyStr
-    interpretation: NonEmptyStr
-
-    @field_validator("question", "query", "interpretation")
-    @classmethod
-    def _non_blank(cls, v: str, info) -> str:
-        return _require_stripped(v, info.field_name)
+    question: NonBlankStr
+    query: NonBlankStr
+    interpretation: NonBlankStr
 
 
 class ConventionDocs(ValueObject):
     """The author-semantics block attached to a Convention at deploy."""
 
-    purpose: NonEmptyStr
+    purpose: NonBlankStr
     # Trigger-only questions (no worked answer); may be empty when the worked
     # examples alone supply the required breadth.
-    example_questions: list[NonEmptyStr] = []
+    example_questions: list[NonBlankStr] = []
     examples: list[Example] = Field(min_length=1)
     when_not_to_use: str | None = None
     see_also: list[str] | None = None
-
-    @field_validator("purpose")
-    @classmethod
-    def _purpose_non_blank(cls, v: str) -> str:
-        return _require_stripped(v, "purpose")
-
-    @field_validator("example_questions")
-    @classmethod
-    def _questions_non_blank(cls, v: list[str]) -> list[str]:
-        for q in v:
-            _require_stripped(q, "example_questions entries")
-        return v
 
     @model_validator(mode="after")
     def _require_trigger_breadth(self) -> "ConventionDocs":

--- a/server/osa/domain/deposition/model/docs.py
+++ b/server/osa/domain/deposition/model/docs.py
@@ -1,0 +1,89 @@
+"""Author-supplied convention documentation (#151).
+
+``ConventionDocs`` is the semantics block attached to every Convention at
+deploy: what the dataset is for, the questions it answers, and worked
+examples rendered verbatim into the reference doc (FR-018). The mandatory
+minimum — non-empty purpose, ≥1 worked example, ≥3 distinct trigger questions
+across ``example_questions ∪ {e.question for e in examples}`` — is encoded in
+the model itself, so an under-documented deploy cannot construct a Convention
+at all (FR-013..016).
+"""
+
+from typing import Annotated
+
+from pydantic import Field, field_validator, model_validator
+
+from osa.domain.shared.model.value import ValueObject
+
+NonEmptyStr = Annotated[str, Field(min_length=1)]
+
+MIN_DISTINCT_TRIGGER_QUESTIONS = 3
+
+
+def _require_stripped(value: str, field_name: str) -> str:
+    if not value.strip():
+        raise ValueError(f"{field_name} must not be empty or whitespace-only")
+    return value
+
+
+class Example(ValueObject):
+    """A worked example: question, opaque query, and what the answer means.
+
+    ``query`` is never parsed, executed, or validated (FR-011) — it is rendered
+    verbatim into the reference doc.
+    """
+
+    question: NonEmptyStr
+    query: NonEmptyStr
+    interpretation: NonEmptyStr
+
+    @field_validator("question", "query", "interpretation")
+    @classmethod
+    def _non_blank(cls, v: str, info) -> str:
+        return _require_stripped(v, info.field_name)
+
+
+class ConventionDocs(ValueObject):
+    """The author-semantics block attached to a Convention at deploy."""
+
+    purpose: NonEmptyStr
+    # Trigger-only questions (no worked answer); may be empty when the worked
+    # examples alone supply the required breadth.
+    example_questions: list[NonEmptyStr] = []
+    examples: list[Example] = Field(min_length=1)
+    when_not_to_use: str | None = None
+    see_also: list[str] | None = None
+
+    @field_validator("purpose")
+    @classmethod
+    def _purpose_non_blank(cls, v: str) -> str:
+        return _require_stripped(v, "purpose")
+
+    @field_validator("example_questions")
+    @classmethod
+    def _questions_non_blank(cls, v: list[str]) -> list[str]:
+        for q in v:
+            _require_stripped(q, "example_questions entries")
+        return v
+
+    @model_validator(mode="after")
+    def _require_trigger_breadth(self) -> "ConventionDocs":
+        distinct = {q.strip() for q in self.example_questions}
+        distinct |= {e.question.strip() for e in self.examples}
+        if len(distinct) < MIN_DISTINCT_TRIGGER_QUESTIONS:
+            raise ValueError(
+                f"need at least {MIN_DISTINCT_TRIGGER_QUESTIONS} distinct trigger "
+                f"questions across example_questions and worked-example questions, "
+                f"got {len(distinct)}"
+            )
+        return self
+
+    def trigger_questions(self) -> list[str]:
+        """The distinct trigger-question union, in first-seen order.
+
+        Feeds the skill frontmatter's trigger prose (FR-002).
+        """
+        seen: dict[str, None] = {}
+        for q in [*self.example_questions, *(e.question for e in self.examples)]:
+            seen.setdefault(q.strip())
+        return list(seen)

--- a/server/osa/domain/deposition/query/get_convention.py
+++ b/server/osa/domain/deposition/query/get_convention.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from osa.domain.deposition.model.docs import ConventionDocs
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.shared.authorization.gate import public
@@ -21,6 +22,7 @@ class ConventionDetail(Result):
     file_requirements: FileRequirements
     hooks: list[HookName]
     ingester: IngesterDefinition | None = None
+    docs: ConventionDocs
     created_at: datetime
 
 
@@ -38,5 +40,6 @@ class GetConventionHandler(QueryHandler[GetConvention, ConventionDetail]):
             file_requirements=conv.file_requirements,
             hooks=list(conv.hooks),
             ingester=conv.ingester,
+            docs=conv.docs,
             created_at=conv.created_at,
         )

--- a/server/osa/domain/deposition/service/convention.py
+++ b/server/osa/domain/deposition/service/convention.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from osa.domain.deposition.event.convention_registered import ConventionRegistered
 from osa.domain.deposition.model.convention import Convention
 from osa.domain.deposition.model.deploy import HookDeploy
+from osa.domain.deposition.model.docs import ConventionDocs
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.deposition.port.convention_repository import ConventionRepository
 from osa.domain.metadata.service.metadata import MetadataService
@@ -43,6 +44,7 @@ class ConventionService(Service):
         schema_version: str,
         schema_fields: list[FieldDefinition],
         description: str,
+        docs: ConventionDocs,
         hooks: list[HookDeploy] | None = None,
         ingester: IngesterDefinition | None = None,
         built_by: str | None = None,
@@ -99,6 +101,7 @@ class ConventionService(Service):
             file_requirements=file_requirements,
             hooks=[spec.identity.name for spec in hooks],
             ingester=ingester,
+            docs=docs,
             created_at=datetime.now(UTC),
         )
         await self.convention_repo.save(convention)

--- a/server/osa/domain/semantics/model/value.py
+++ b/server/osa/domain/semantics/model/value.py
@@ -78,3 +78,4 @@ class FieldDefinition(ValueObject):
     cardinality: Cardinality
     description: str | None = None
     constraints: FieldConstraints | None = None
+    examples: list[str] | None = None

--- a/server/osa/domain/shared/model/hook.py
+++ b/server/osa/domain/shared/model/hook.py
@@ -125,6 +125,8 @@ class ColumnDef(ValueObject):
     json_type: Literal["string", "number", "integer", "boolean", "array", "object"]
     format: str | None = None
     required: bool
+    description: str | None = None
+    unit: str | None = None
 
 
 # ── Runtime variants ──

--- a/server/osa/infrastructure/data/postgres_catalog_read_store.py
+++ b/server/osa/infrastructure/data/postgres_catalog_read_store.py
@@ -133,7 +133,7 @@ class PostgresCatalogReadStore:
         return NodeCatalog(node_domain=self.node_domain.root, schemas=entries)
 
     async def get_schema_manifest(self, schema_id: SchemaId) -> SchemaManifest | None:
-        stmt = select(schemas_table.c.fields).where(
+        stmt = select(schemas_table.c.title, schemas_table.c.fields).where(
             schemas_table.c.id == schema_id.id.root,
             schemas_table.c.version == schema_id.version.root,
         )
@@ -152,6 +152,10 @@ class PostgresCatalogReadStore:
                     type=ftype,
                     ontology_id=f.get("ontology_id"),
                     ontology_version=f.get("ontology_version"),
+                    description=f.get("description"),
+                    # Hoisted for consumers; the constraints union itself stays internal.
+                    unit=(f.get("constraints") or {}).get("unit"),
+                    examples=f.get("examples"),
                 )
             )
             column_specs.append(ColumnSpec(name=f["name"], type=ftype))
@@ -171,6 +175,7 @@ class PostgresCatalogReadStore:
             id=schema_id.id.root,
             version=schema_id.version.root,
             srn=schema_id.to_srn(self.node_domain).render(),
+            title=row["title"],
             fields=field_specs,
             table_resources=[records_resource, *feature_resources],
         )
@@ -220,6 +225,12 @@ class PostgresCatalogReadStore:
     def _feature_column_specs(fschema: FeatureSchema) -> list[ColumnSpec]:
         """Map a feature table's declared columns to manifest ColumnSpecs."""
         return [
-            ColumnSpec(name=c.name, type=_JSON_TYPE_TO_FIELD_TYPE[c.json_type])
+            ColumnSpec(
+                name=c.name,
+                type=_JSON_TYPE_TO_FIELD_TYPE[c.json_type],
+                format=c.format,
+                description=c.description,
+                unit=c.unit,
+            )
             for c in fschema.columns
         ]

--- a/server/osa/infrastructure/data/postgres_catalog_read_store.py
+++ b/server/osa/infrastructure/data/postgres_catalog_read_store.py
@@ -28,6 +28,7 @@ from osa.domain.data.model.manifest import (
 )
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.record_summary import RecordSummary
+from osa.domain.data.model.skill import AuthorDocs, SampleValue
 from osa.domain.semantics.model.value import FieldType
 from osa.domain.shared.model.ids import RecordId
 from osa.domain.shared.model.srn import Domain, RecordSRN, SchemaId
@@ -36,7 +37,11 @@ from osa.infrastructure.persistence.feature_table import (
     FeatureSchema,
     build_feature_table,
 )
-from osa.infrastructure.persistence.tables import records_table, schemas_table
+from osa.infrastructure.persistence.tables import (
+    conventions_table,
+    records_table,
+    schemas_table,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +203,80 @@ class PostgresCatalogReadStore:
                 )
             )
         return resources
+
+    # ------------------------------------------------------------------ #
+    # Skill surface projections (#151)
+    # ------------------------------------------------------------------ #
+
+    async def get_author_docs(self, schema_id: str, version: str) -> AuthorDocs | None:
+        """Docs of the schema's owning convention — a read-model projection over
+        the deposition-owned ``conventions`` table (latest deploy wins)."""
+        stmt = (
+            select(conventions_table.c.docs)
+            .where(
+                conventions_table.c.schema_id == schema_id,
+                conventions_table.c.schema_version == version,
+            )
+            .order_by(conventions_table.c.created_at.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        row = result.first()
+        if row is None:
+            return None
+        return AuthorDocs.model_validate(row[0])
+
+    async def sample_value(
+        self, schema_id: SchemaId, table: str, column: str
+    ) -> SampleValue | None:
+        """One non-null value for example templating (research §9).
+
+        Records sampling extracts the JSONB metadata element (bound parameter,
+        no identifier interpolation); feature tables go through the existing
+        quoted dynamic-table machinery. ``None`` on empty/unknown columns.
+        """
+        if table == "records":
+            t = records_table
+            element = t.c.metadata[column]
+            stmt = (
+                select(element)
+                .where(
+                    t.c.schema_id == schema_id.id.root,
+                    t.c.schema_version == schema_id.version.root,
+                    # ->> is SQL NULL for both a missing key and a JSON null.
+                    t.c.metadata[column].astext.isnot(None),
+                )
+                .limit(1)
+            )
+        else:
+            fschema = next(
+                (
+                    fs
+                    for name, fs in await self._features.feature_tables(schema_id)
+                    if name == table
+                ),
+                None,
+            )
+            if fschema is None:
+                return None
+            ft = build_feature_table(table, fschema)
+            if column not in ft.c:
+                return None
+            stmt = (
+                select(ft.c[column])
+                .select_from(ft.join(records_table, records_table.c.srn == ft.c.record_srn))
+                .where(
+                    records_table.c.schema_id == schema_id.id.root,
+                    records_table.c.schema_version == schema_id.version.root,
+                    ft.c[column].isnot(None),
+                )
+                .limit(1)
+            )
+        result = await self.session.execute(stmt)
+        row = result.first()
+        if row is None or not isinstance(row[0], (str, int, float, bool)):
+            return None
+        return SampleValue(value=row[0])
 
     async def get_latest_schema_id(self, schema_short_id: str) -> SchemaId | None:
         stmt = select(schemas_table.c.version).where(schemas_table.c.id == schema_short_id)

--- a/server/osa/infrastructure/data/postgres_catalog_read_store.py
+++ b/server/osa/infrastructure/data/postgres_catalog_read_store.py
@@ -29,7 +29,12 @@ from osa.domain.data.model.manifest import (
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.record_summary import RecordSummary
 from osa.domain.data.model.skill import AuthorDocs, SampleValue
-from osa.domain.semantics.model.value import FieldType
+from osa.domain.semantics.model.value import (
+    FieldDefinition,
+    FieldType,
+    NumberConstraints,
+    TermConstraints,
+)
 from osa.domain.shared.model.ids import RecordId
 from osa.domain.shared.model.srn import Domain, RecordSRN, SchemaId
 from osa.infrastructure.data.schema_feature_reader import SchemaFeatureReader
@@ -150,20 +155,30 @@ class PostgresCatalogReadStore:
         field_specs: list[FieldSpec] = []
         column_specs: list[ColumnSpec] = []
         for f in row["fields"]:
-            ftype = FieldType(f["type"])
+            # The blob IS a serialized FieldDefinition — validate it back into
+            # the domain model and read typed attributes, never raw dict keys.
+            fd = FieldDefinition.model_validate(f)
+            ontology_id: str | None = None
+            ontology_version: str | None = None
+            unit: str | None = None
+            if isinstance(fd.constraints, TermConstraints):
+                ontology_id = fd.constraints.ontology_srn.id.root
+                ontology_version = fd.constraints.ontology_srn.version.root
+            elif isinstance(fd.constraints, NumberConstraints):
+                # Hoisted for consumers; the constraints union stays internal.
+                unit = fd.constraints.unit
             field_specs.append(
                 FieldSpec(
-                    name=f["name"],
-                    type=ftype,
-                    ontology_id=f.get("ontology_id"),
-                    ontology_version=f.get("ontology_version"),
-                    description=f.get("description"),
-                    # Hoisted for consumers; the constraints union itself stays internal.
-                    unit=(f.get("constraints") or {}).get("unit"),
-                    examples=f.get("examples"),
+                    name=fd.name,
+                    type=fd.type,
+                    ontology_id=ontology_id,
+                    ontology_version=ontology_version,
+                    description=fd.description,
+                    unit=unit,
+                    examples=fd.examples,
                 )
             )
-            column_specs.append(ColumnSpec(name=f["name"], type=ftype))
+            column_specs.append(ColumnSpec(name=fd.name, type=fd.type))
 
         record_count = await self._records_count(schema_id)
         records_resource = TableResource(
@@ -208,14 +223,14 @@ class PostgresCatalogReadStore:
     # Skill surface projections (#151)
     # ------------------------------------------------------------------ #
 
-    async def get_author_docs(self, schema_id: str, version: str) -> AuthorDocs | None:
+    async def get_author_docs(self, schema_id: SchemaId) -> AuthorDocs | None:
         """Docs of the schema's owning convention — a read-model projection over
         the deposition-owned ``conventions`` table (latest deploy wins)."""
         stmt = (
             select(conventions_table.c.docs)
             .where(
-                conventions_table.c.schema_id == schema_id,
-                conventions_table.c.schema_version == version,
+                conventions_table.c.schema_id == schema_id.id.root,
+                conventions_table.c.schema_version == schema_id.version.root,
             )
             .order_by(conventions_table.c.created_at.desc())
             .limit(1)

--- a/server/osa/infrastructure/persistence/repository/convention.py
+++ b/server/osa/infrastructure/persistence/repository/convention.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from osa.domain.deposition.model.convention import Convention
+from osa.domain.deposition.model.docs import ConventionDocs
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.deposition.port.convention_repository import ConventionRepository
 from osa.domain.shared.model.source import IngesterDefinition
@@ -22,6 +23,7 @@ def _convention_to_row(convention: Convention) -> dict[str, Any]:
         "file_requirements": convention.file_requirements.model_dump(),
         "hooks": [name.root for name in convention.hooks],  # hook-name registry refs
         "source": convention.ingester.model_dump() if convention.ingester else None,
+        "docs": convention.docs.model_dump(mode="json"),
         "created_at": convention.created_at,
     }
 
@@ -39,6 +41,7 @@ def _row_to_convention(row: dict[str, Any]) -> Convention:
         file_requirements=FileRequirements.model_validate(row["file_requirements"]),
         hooks=list(row.get("hooks") or []),
         ingester=IngesterDefinition.model_validate(source_data) if source_data else None,
+        docs=ConventionDocs.model_validate(row["docs"]),
         created_at=row["created_at"],
     )
 
@@ -63,6 +66,7 @@ class PostgresConventionRepository(ConventionRepository):
                 "file_requirements": stmt.excluded.file_requirements,
                 "hooks": stmt.excluded.hooks,
                 "source": stmt.excluded.source,
+                "docs": stmt.excluded.docs,
             },
         )
         await self.session.execute(stmt)

--- a/server/osa/infrastructure/persistence/tables.py
+++ b/server/osa/infrastructure/persistence/tables.py
@@ -289,6 +289,7 @@ conventions_table = Table(
     Column("file_requirements", JSON, nullable=False),  # FileRequirements as dict
     Column("hooks", JSON, nullable=False, default=[]),  # List of hook names (str) — registry refs
     Column("source", JSON, nullable=True),  # IngesterDefinition as dict
+    Column("docs", JSONB, nullable=False),  # ConventionDocs as dict — mandatory (#151)
     Column("created_at", DateTime(timezone=True), nullable=False),
 )
 

--- a/server/tests/contract/test_conventions_docs_gate.py
+++ b/server/tests/contract/test_conventions_docs_gate.py
@@ -1,0 +1,154 @@
+"""DB-free contract tests for the mandatory-docs deploy gate (#151, US2).
+
+``POST /api/v1/conventions`` rejects any payload without a complete ``docs``
+block with a 422 whose field-level errors name each gap — regardless of client
+(FR-015/016). Body validation runs at the route layer, before auth/DI, so
+these tests need no database and no credentials.
+
+Persistence round-trip lives in
+``tests/integration/test_convention_docs_postgres.py``.
+"""
+
+import os
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from osa.domain.deposition.command.create_convention import DeployConvention
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-contract-tests-minimum-32-chars")
+
+
+def _client() -> AsyncClient:
+    from osa.application.api.rest.app import create_app
+
+    return AsyncClient(transport=ASGITransport(app=create_app()), base_url="http://test")
+
+
+def _docs_block() -> dict[str, Any]:
+    return {
+        "purpose": "Test-campaign results for structural alloys.",
+        "example_questions": [
+            "Which alloys stay ductile below -40C?",
+            "What is the yield strength range for 7xxx-series samples?",
+            "Which samples have corrosion panels attached?",
+        ],
+        "examples": [
+            {
+                "question": "Which alloys stay ductile below -40C?",
+                "query": 'POST /api/v1/data/alloy-tests/records {"filter": {}}',
+                "interpretation": "Rows are individual test coupons.",
+            }
+        ],
+    }
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "title": "Alloy Ductility Tests",
+        "description": "Mechanical test results for structural alloys",
+        "file_requirements": {
+            "accepted_types": [".csv"],
+            "min_count": 0,
+            "max_count": 5,
+            "max_file_size": 100_000_000,
+        },
+        "schema": {
+            "id": "alloy-tests",
+            "version": "2.1.0",
+            "fields": [
+                {
+                    "name": "alloy",
+                    "type": "text",
+                    "required": True,
+                    "cardinality": "exactly_one",
+                }
+            ],
+        },
+        "hooks": [],
+        "docs": _docs_block(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _post(payload: dict[str, Any]):
+    async with _client() as client:
+        return await client.post("/api/v1/conventions", json=payload)
+
+
+def _error_locs(resp) -> list[tuple]:
+    return [tuple(err["loc"]) for err in resp.json()["detail"]]
+
+
+@pytest.mark.asyncio
+class TestDocsGate:
+    async def test_missing_docs_block_rejected_naming_the_gap(self):
+        payload = _payload()
+        del payload["docs"]
+        resp = await _post(payload)
+        assert resp.status_code == 422
+        assert ("body", "docs") in _error_locs(resp)
+
+    async def test_empty_purpose_rejected_naming_the_field(self):
+        docs = _docs_block()
+        docs["purpose"] = "   "
+        resp = await _post(_payload(docs=docs))
+        assert resp.status_code == 422
+        assert any(loc[:3] == ("body", "docs", "purpose") for loc in _error_locs(resp))
+
+    async def test_too_few_distinct_trigger_questions_rejected(self):
+        docs = _docs_block()
+        # 1 trigger question + 1 worked example repeating it = 1 distinct.
+        docs["example_questions"] = ["Which alloys stay ductile below -40C?"]
+        resp = await _post(_payload(docs=docs))
+        assert resp.status_code == 422
+        locs = _error_locs(resp)
+        assert any(loc[:2] == ("body", "docs") for loc in locs)
+        detail = resp.json()["detail"]
+        assert any("3" in err["msg"] for err in detail)
+
+    async def test_zero_examples_rejected_naming_the_field(self):
+        docs = _docs_block()
+        docs["examples"] = []
+        resp = await _post(_payload(docs=docs))
+        assert resp.status_code == 422
+        assert any(loc[:3] == ("body", "docs", "examples") for loc in _error_locs(resp))
+
+    async def test_multiple_gaps_all_named(self):
+        docs = _docs_block()
+        docs["purpose"] = ""
+        docs["examples"] = []
+        resp = await _post(_payload(docs=docs))
+        assert resp.status_code == 422
+        locs = _error_locs(resp)
+        assert any(loc[:3] == ("body", "docs", "purpose") for loc in locs)
+        assert any(loc[:3] == ("body", "docs", "examples") for loc in locs)
+
+    async def test_extra_fields_still_forbidden(self):
+        resp = await _post(_payload(unexpected="boom"))
+        assert resp.status_code == 422
+
+    async def test_extra_fields_inside_docs_forbidden(self):
+        docs = _docs_block()
+        docs["unexpected"] = "boom"
+        resp = await _post(_payload(docs=docs))
+        assert resp.status_code == 422
+
+
+class TestFullyDocumentedPayloadValidates:
+    def test_valid_payload_passes_dto_validation(self):
+        # The full HTTP deploy round-trip (auth + DB) lives in the integration
+        # suite; here we assert the DTO gate itself accepts a complete payload.
+        cmd = DeployConvention.model_validate(_payload())
+        assert cmd.docs.purpose.startswith("Test-campaign")
+        assert len(cmd.docs.examples) == 1
+
+    def test_worked_example_questions_count_toward_three(self):
+        docs = _docs_block()
+        docs["example_questions"] = ["q1?", "q2?"]
+        docs["examples"][0]["question"] = "q3?"
+        cmd = DeployConvention.model_validate(_payload(docs=docs))
+        assert len(cmd.docs.example_questions) == 2

--- a/server/tests/contract/test_manifest_enrichment.py
+++ b/server/tests/contract/test_manifest_enrichment.py
@@ -1,0 +1,106 @@
+"""DB-free contract tests for the enriched schema manifest (#151, US3).
+
+The manifest DTOs gain optional metadata (`title`, field `description`/`unit`/
+`examples`, column `format`/`description`/`unit`) — strictly additive (FR-019).
+Absent attributes must be omitted from serialized output so a field carrying
+none of the new attributes serializes exactly as before (AS-2 regression).
+
+DB-backed round-trip behaviour lives in
+``tests/integration/test_manifest_enrichment_postgres.py``.
+"""
+
+import os
+
+from osa.domain.data.model.manifest import ColumnSpec, FieldSpec, SchemaManifest
+from osa.domain.semantics.model.value import FieldType
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-contract-tests-minimum-32-chars")
+
+
+class TestFieldSpecEnrichment:
+    def test_accepts_description_unit_examples(self):
+        spec = FieldSpec(
+            name="yield_strength",
+            type=FieldType.NUMBER,
+            description="0.2% offset yield strength",
+            unit="MPa",
+            examples=["512"],
+        )
+        assert spec.description == "0.2% offset yield strength"
+        assert spec.unit == "MPa"
+        assert spec.examples == ["512"]
+
+    def test_bare_field_serializes_exactly_as_today(self):
+        # AS-2 regression: no new keys appear on a field with no new attributes.
+        spec = FieldSpec(name="alloy", type=FieldType.TEXT)
+        assert spec.model_dump(exclude_none=True) == {"name": "alloy", "type": FieldType.TEXT}
+
+    def test_term_field_keeps_ontology_ref_without_new_keys(self):
+        spec = FieldSpec(
+            name="tissue",
+            type=FieldType.TERM,
+            ontology_id="uberon",
+            ontology_version="2025-01-15",
+        )
+        assert spec.model_dump(exclude_none=True) == {
+            "name": "tissue",
+            "type": FieldType.TERM,
+            "ontology_id": "uberon",
+            "ontology_version": "2025-01-15",
+        }
+
+
+class TestColumnSpecEnrichment:
+    def test_accepts_format_description_unit(self):
+        spec = ColumnSpec(
+            name="transition_temp",
+            type=FieldType.NUMBER,
+            format="float",
+            description="Ductile-brittle transition",
+            unit="°C",
+        )
+        assert spec.format == "float"
+        assert spec.description == "Ductile-brittle transition"
+        assert spec.unit == "°C"
+
+    def test_bare_column_serializes_exactly_as_today(self):
+        spec = ColumnSpec(name="score", type=FieldType.NUMBER)
+        assert spec.model_dump(exclude_none=True) == {"name": "score", "type": FieldType.NUMBER}
+
+
+class TestSchemaManifestEnrichment:
+    def test_accepts_title(self):
+        manifest = SchemaManifest(
+            id="alloy-tests",
+            version="2.1.0",
+            srn="urn:osa:localhost:schema:alloy-tests@2.1.0",
+            title="Alloy Ductility Tests",
+            fields=[],
+            table_resources=[],
+        )
+        assert manifest.title == "Alloy Ductility Tests"
+
+    def test_title_defaults_to_none(self):
+        manifest = SchemaManifest(
+            id="alloy-tests",
+            version="2.1.0",
+            srn="urn:osa:localhost:schema:alloy-tests@2.1.0",
+            fields=[],
+            table_resources=[],
+        )
+        assert manifest.title is None
+        assert "title" not in manifest.model_dump(exclude_none=True)
+
+
+def test_manifest_route_omits_absent_attributes():
+    """The manifest route must serialize with exclude_none so absent metadata
+    never appears as ``null`` keys on the wire (FR-019/AS-2)."""
+    from osa.application.api.rest.app import create_app
+
+    app = create_app()
+    route = next(
+        r for r in app.routes if getattr(r, "operation_id", None) == "data_get_schema_manifest"
+    )
+    assert route.response_model is SchemaManifest
+    assert route.response_model_exclude_none is True

--- a/server/tests/contract/test_manifest_enrichment.py
+++ b/server/tests/contract/test_manifest_enrichment.py
@@ -70,7 +70,7 @@ class TestColumnSpecEnrichment:
 
 
 class TestSchemaManifestEnrichment:
-    def test_accepts_title(self):
+    def test_carries_title(self):
         manifest = SchemaManifest(
             id="alloy-tests",
             version="2.1.0",
@@ -81,16 +81,19 @@ class TestSchemaManifestEnrichment:
         )
         assert manifest.title == "Alloy Ductility Tests"
 
-    def test_title_defaults_to_none(self):
-        manifest = SchemaManifest(
-            id="alloy-tests",
-            version="2.1.0",
-            srn="urn:osa:localhost:schema:alloy-tests@2.1.0",
-            fields=[],
-            table_resources=[],
-        )
-        assert manifest.title is None
-        assert "title" not in manifest.model_dump(exclude_none=True)
+    def test_title_is_required(self):
+        # schemas.title is NOT NULL — a title-less manifest is unrepresentable.
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SchemaManifest(
+                id="alloy-tests",
+                version="2.1.0",
+                srn="urn:osa:localhost:schema:alloy-tests@2.1.0",
+                fields=[],
+                table_resources=[],
+            )  # type: ignore[call-arg]
 
 
 def test_manifest_route_omits_absent_attributes():

--- a/server/tests/contract/test_skill_surface.py
+++ b/server/tests/contract/test_skill_surface.py
@@ -1,0 +1,61 @@
+"""DB-free contract tests for the skill surface routing (#151, US1).
+
+Asserts what routing alone can prove without Postgres: the unprefixed root
+routes exist, the ``.md`` reference route is registered before the
+``/{schema}`` manifest catch-all (longest-suffix-first, like ``.csv``), and
+reserved ids 404 via ``resolve_schema``'s guard (which runs before any DB
+query).
+
+Full-response shape (root discovery JSON, SKILL.md frontmatter, reference
+markdown vs JSON manifest) is DB-backed and lives in
+``tests/integration/test_skill_surface_postgres.py``.
+"""
+
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-contract-tests-minimum-32-chars")
+
+
+def _app():
+    from osa.application.api.rest.app import create_app
+
+    return create_app()
+
+
+def _route_paths(app) -> list[str]:
+    return [r.path for r in app.routes if hasattr(r, "path")]
+
+
+class TestRootRoutesRegistered:
+    def test_root_discovery_route_exists_unprefixed(self):
+        assert "/" in _route_paths(_app())
+
+    def test_skill_md_route_exists_unprefixed(self):
+        assert "/SKILL.md" in _route_paths(_app())
+
+    def test_reference_route_exists_on_data_surface(self):
+        assert "/api/v1/data/{schema}.md" in _route_paths(_app())
+
+
+class TestReferenceRouteOrdering:
+    def test_md_route_registered_before_manifest_catch_all(self):
+        # Route-ordering regression: `/{schema}.md` must precede `/{schema}`
+        # or the manifest catch-all would capture `alloy-tests.md`.
+        paths = _route_paths(_app())
+        assert paths.index("/api/v1/data/{schema}.md") < paths.index("/api/v1/data/{schema}")
+
+
+@pytest.mark.asyncio
+class TestReservedReferenceIds:
+    @pytest.mark.parametrize("reserved", ["records", "datasets", "runs"])
+    async def test_reserved_ids_404(self, reserved: str):
+        # resolve_schema rejects reserved names before touching the DB, so
+        # this contract holds without Postgres (FR-024).
+        client = AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test")
+        async with client:
+            resp = await client.get(f"/api/v1/data/{reserved}.md")
+        assert resp.status_code == 404

--- a/server/tests/factories.py
+++ b/server/tests/factories.py
@@ -1,0 +1,31 @@
+"""Shared test factories for cross-cutting model construction."""
+
+from typing import Any
+
+from osa.domain.deposition.model.docs import ConventionDocs, Example
+
+
+def make_convention_docs(**overrides: Any) -> ConventionDocs:
+    """A minimal valid ``ConventionDocs`` — every convention must carry docs (#151)."""
+    kwargs: dict[str, Any] = {
+        "purpose": "Test-campaign data for unit tests.",
+        "example_questions": [
+            "What records exist?",
+            "Which samples pass validation?",
+            "What is the value range for field X?",
+        ],
+        "examples": [
+            Example(
+                question="What records exist?",
+                query="GET /api/v1/data/test/records",
+                interpretation="One row per deposited record.",
+            )
+        ],
+    }
+    kwargs.update(overrides)
+    return ConventionDocs(**kwargs)
+
+
+def make_convention_docs_dict(**overrides: Any) -> dict[str, Any]:
+    """The same minimal docs block as a JSON-ready dict (for raw row inserts)."""
+    return make_convention_docs(**overrides).model_dump(mode="json")

--- a/server/tests/integration/persistence/test_convention_repo.py
+++ b/server/tests/integration/persistence/test_convention_repo.py
@@ -26,6 +26,8 @@ from osa.infrastructure.persistence.repository.convention import (
     PostgresConventionRepository,
 )
 
+from tests.factories import make_convention_docs
+
 
 def _make_convention(
     *,
@@ -48,6 +50,7 @@ def _make_convention(
         ),
         hooks=hooks or [],
         ingester=ingester,
+        docs=make_convention_docs(),
         created_at=datetime.now(UTC),
     )
 

--- a/server/tests/integration/test_bulk_publish_dual_write.py
+++ b/server/tests/integration/test_bulk_publish_dual_write.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from tests.factories import make_convention_docs
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -91,6 +92,7 @@ async def _register_convention(
         schema_slug=SchemaIdentifier(slug),
         schema_version="1.0.0",
         schema_fields=_fields(),
+        docs=make_convention_docs(),
     )
     await pg_session.commit()
     return convention_service

--- a/server/tests/integration/test_convention_docs_postgres.py
+++ b/server/tests/integration/test_convention_docs_postgres.py
@@ -1,0 +1,129 @@
+"""Integration tests for ``conventions.docs`` persistence against real Postgres (#151, US2).
+
+Docs persist as a ``NOT NULL`` JSONB column; the slug-keyed re-deploy (upsert)
+replaces them wholesale; ``GET /api/v1/conventions/{slug}`` (public) returns
+the docs block for author read-back.
+
+Skips automatically unless OSA_DATABASE__URL points at PostgreSQL.
+"""
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from osa.domain.deposition.model.convention import Convention
+from osa.domain.deposition.model.docs import ConventionDocs, Example
+from osa.domain.deposition.model.value import FileRequirements
+from osa.domain.shared.model.srn import ConventionSlug, SchemaId
+from osa.infrastructure.persistence.repository.convention import (
+    PostgresConventionRepository,
+)
+from osa.infrastructure.persistence.tables import conventions_table
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-integration-tests-minimum-32-chars")
+
+if "postgresql" not in os.environ.get("OSA_DATABASE__URL", ""):
+    pytest.skip("OSA_DATABASE__URL not set to PostgreSQL", allow_module_level=True)
+
+
+def _docs(purpose: str = "Test-campaign results for structural alloys.") -> ConventionDocs:
+    return ConventionDocs(
+        purpose=purpose,
+        example_questions=[
+            "Which alloys stay ductile below -40C?",
+            "What is the yield strength range for 7xxx-series samples?",
+            "Which samples have corrosion panels attached?",
+        ],
+        examples=[
+            Example(
+                question="Which alloys stay ductile below -40C?",
+                query='POST /api/v1/data/alloy-tests/records {"filter": {}}',
+                interpretation="Rows are individual test coupons.",
+            )
+        ],
+        when_not_to_use="Not a materials-property database.",
+        see_also=["https://other-node.example.org"],
+    )
+
+
+def _convention(docs: ConventionDocs) -> Convention:
+    return Convention(
+        id=ConventionSlug.parse("alloy-tests-conv"),
+        title="Alloy Ductility Tests",
+        description="Mechanical test results",
+        schema_id=SchemaId.parse("alloy-tests@2.1.0"),
+        file_requirements=FileRequirements(
+            accepted_types=[".csv"], min_count=0, max_count=5, max_file_size=100_000_000
+        ),
+        hooks=[],
+        ingester=None,
+        docs=docs,
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+class TestConventionDocsRoundTrip:
+    async def test_deploy_persists_docs(self, pg_session: AsyncSession):
+        repo = PostgresConventionRepository(pg_session)
+        await repo.save(_convention(_docs()))
+        await pg_session.commit()
+
+        row = (
+            (
+                await pg_session.execute(
+                    select(conventions_table.c.docs).where(
+                        conventions_table.c.id == "alloy-tests-conv"
+                    )
+                )
+            )
+            .mappings()
+            .first()
+        )
+        assert row is not None
+        assert row["docs"]["purpose"] == "Test-campaign results for structural alloys."
+
+        loaded = await repo.get(ConventionSlug.parse("alloy-tests-conv"))
+        assert loaded is not None
+        assert loaded.docs == _docs()
+
+    async def test_redeploy_replaces_docs_wholesale(self, pg_session: AsyncSession):
+        repo = PostgresConventionRepository(pg_session)
+        await repo.save(_convention(_docs()))
+        await pg_session.commit()
+
+        new_docs = ConventionDocs(
+            purpose="A completely new purpose.",
+            example_questions=["a?", "b?", "c?"],
+            examples=[Example(question="a?", query="GET /x", interpretation="means x")],
+        )
+        await repo.save(_convention(new_docs))
+        await pg_session.commit()
+
+        loaded = await repo.get(ConventionSlug.parse("alloy-tests-conv"))
+        assert loaded is not None
+        assert loaded.docs == new_docs
+        # Replaced wholesale — optional fields from the first deploy are gone.
+        assert loaded.docs.when_not_to_use is None
+        assert loaded.docs.see_also is None
+
+    async def test_get_convention_returns_docs_block(self, pg_session: AsyncSession):
+        repo = PostgresConventionRepository(pg_session)
+        await repo.save(_convention(_docs()))
+        await pg_session.commit()
+
+        from osa.application.api.rest.app import create_app
+
+        client = AsyncClient(transport=ASGITransport(app=create_app()), base_url="http://test")
+        async with client:
+            resp = await client.get("/api/v1/conventions/alloy-tests-conv")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["docs"]["purpose"] == "Test-campaign results for structural alloys."
+        assert len(body["docs"]["examples"]) == 1
+        assert body["docs"]["examples"][0]["question"] == "Which alloys stay ductile below -40C?"

--- a/server/tests/integration/test_data_features_postgres.py
+++ b/server/tests/integration/test_data_features_postgres.py
@@ -39,6 +39,7 @@ from osa.infrastructure.persistence.repository.schema import (
 from osa.infrastructure.persistence.tables import conventions_table
 
 from tests.integration.conftest import seed_hook_run, seed_record
+from tests.factories import make_convention_docs_dict
 
 SCHEMA = SchemaId.parse("compound@1.0.0")
 SCHEMA_B = SchemaId.parse("protein@1.0.0")
@@ -100,6 +101,7 @@ async def _register_hook(
             file_requirements={},
             hooks=[hook_name],
             source=None,
+            docs=make_convention_docs_dict(),
             created_at=datetime.now(UTC),
         )
     )

--- a/server/tests/integration/test_data_routes_e2e_postgres.py
+++ b/server/tests/integration/test_data_routes_e2e_postgres.py
@@ -31,6 +31,7 @@ from osa.infrastructure.persistence.repository.schema import (
 from osa.infrastructure.persistence.tables import conventions_table
 
 from tests.integration.conftest import seed_hook_run, seed_record
+from tests.factories import make_convention_docs_dict
 
 # create_app() reads Config() at import/call time; localhost domain needs a base URL.
 os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
@@ -105,6 +106,7 @@ async def _seed_feature(
             file_requirements={},
             hooks=[HOOK],
             source=None,
+            docs=make_convention_docs_dict(),
             created_at=datetime.now(UTC),
         )
     )

--- a/server/tests/integration/test_manifest_enrichment_postgres.py
+++ b/server/tests/integration/test_manifest_enrichment_postgres.py
@@ -1,0 +1,191 @@
+"""Integration tests for the enriched schema manifest against a real Postgres (#151, US3).
+
+Deploy → manifest round-trip: field descriptions/units/examples persisted in
+the ``schemas.fields`` JSON blob and column format/description/unit persisted
+in the feature-table schema come back through ``get_schema_manifest`` — and
+through the HTTP route with absent attributes omitted (FR-019/AS-2).
+
+Skips automatically unless OSA_DATABASE__URL points at PostgreSQL.
+"""
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from osa.domain.semantics.model.schema import Schema
+from osa.domain.semantics.model.value import (
+    Cardinality,
+    FieldDefinition,
+    FieldType,
+    NumberConstraints,
+)
+from osa.domain.shared.error import ConflictError
+from osa.domain.shared.model.hook import ColumnDef
+from osa.domain.shared.model.srn import Domain, SchemaId
+from osa.infrastructure.data.postgres_catalog_read_store import PostgresCatalogReadStore
+from osa.infrastructure.persistence.feature_store import PostgresFeatureStore
+from osa.infrastructure.persistence.metadata_store import PostgresMetadataStore
+from osa.infrastructure.persistence.repository.schema import (
+    PostgresSemanticsSchemaRepository,
+)
+from osa.infrastructure.persistence.tables import conventions_table
+
+from tests.integration.conftest import seed_hook_run
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-integration-tests-minimum-32-chars")
+
+if "postgresql" not in os.environ.get("OSA_DATABASE__URL", ""):
+    pytest.skip("OSA_DATABASE__URL not set to PostgreSQL", allow_module_level=True)
+
+SCHEMA = SchemaId.parse("alloy-tests@2.1.0")
+HOOK = "ductility"
+
+
+def _fields() -> list[FieldDefinition]:
+    return [
+        FieldDefinition(
+            name="yield_strength",
+            type=FieldType.NUMBER,
+            required=True,
+            cardinality=Cardinality.EXACTLY_ONE,
+            description="0.2% offset yield strength",
+            constraints=NumberConstraints(unit="MPa"),
+            examples=["512"],
+        ),
+        FieldDefinition(
+            name="alloy",
+            type=FieldType.TEXT,
+            required=True,
+            cardinality=Cardinality.EXACTLY_ONE,
+        ),
+    ]
+
+
+def _feature_columns() -> list[ColumnDef]:
+    return [
+        ColumnDef(
+            name="transition_temp",
+            json_type="number",
+            format="float",
+            required=True,
+            description="Ductile-brittle transition",
+            unit="°C",
+        ),
+        ColumnDef(name="batch", json_type="string", required=False),
+    ]
+
+
+async def _seed(engine: AsyncEngine, session: AsyncSession) -> None:
+    store = PostgresMetadataStore(engine, session)
+    await store.ensure_table(SCHEMA, _fields())
+    await PostgresSemanticsSchemaRepository(session).save(
+        Schema(
+            id=SCHEMA,
+            title="Alloy Ductility Tests",
+            fields=_fields(),
+            created_at=datetime.now(UTC),
+        )
+    )
+    await session.execute(
+        conventions_table.insert().values(
+            id="alloy-tests-conv",
+            title="Alloy conv",
+            description="Alloy convention",
+            schema_id=SCHEMA.id.root,
+            schema_version=SCHEMA.version.root,
+            file_requirements={},
+            hooks=[HOOK],
+            source=None,
+            created_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+    await seed_hook_run(engine, feature_name=HOOK, columns=_feature_columns())
+    feature_store = PostgresFeatureStore(engine, session)
+    try:
+        await feature_store.create_table(HOOK, _feature_columns())
+    except ConflictError:
+        pass
+
+
+@pytest.mark.asyncio
+class TestManifestEnrichmentReadStore:
+    async def test_field_metadata_round_trips(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        await _seed(pg_engine, pg_session)
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        manifest = await rs.get_schema_manifest(SCHEMA)
+        assert manifest is not None
+
+        assert manifest.title == "Alloy Ductility Tests"
+
+        by_name = {f.name: f for f in manifest.fields}
+        enriched = by_name["yield_strength"]
+        assert enriched.description == "0.2% offset yield strength"
+        assert enriched.unit == "MPa"
+        assert enriched.examples == ["512"]
+
+        bare = by_name["alloy"]
+        assert bare.description is None
+        assert bare.unit is None
+        assert bare.examples is None
+
+    async def test_feature_column_metadata_round_trips(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        await _seed(pg_engine, pg_session)
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        manifest = await rs.get_schema_manifest(SCHEMA)
+        assert manifest is not None
+
+        feature = next(t for t in manifest.table_resources if t.name == HOOK)
+        by_name = {c.name: c for c in feature.columns}
+        enriched = by_name["transition_temp"]
+        assert enriched.format == "float"
+        assert enriched.description == "Ductile-brittle transition"
+        assert enriched.unit == "°C"
+
+        bare = by_name["batch"]
+        assert bare.format is None
+        assert bare.description is None
+        assert bare.unit is None
+
+
+@pytest.mark.asyncio
+class TestManifestEnrichmentHttp:
+    async def test_manifest_route_serializes_enrichment_and_omits_absent(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        await _seed(pg_engine, pg_session)
+
+        from osa.application.api.rest.app import create_app
+
+        client = AsyncClient(transport=ASGITransport(app=create_app()), base_url="http://test")
+        async with client:
+            resp = await client.get("/api/v1/data/alloy-tests@2.1.0")
+        assert resp.status_code == 200
+        manifest = resp.json()
+
+        assert manifest["title"] == "Alloy Ductility Tests"
+
+        by_name = {f["name"]: f for f in manifest["fields"]}
+        enriched = by_name["yield_strength"]
+        assert enriched["description"] == "0.2% offset yield strength"
+        assert enriched["unit"] == "MPa"
+        assert enriched["examples"] == ["512"]
+
+        # AS-2: a field with none of the new attributes carries no new keys —
+        # and no null-valued keys at all.
+        assert by_name["alloy"] == {"name": "alloy", "type": "text"}
+
+        feature = next(t for t in manifest["table_resources"] if t["name"] == HOOK)
+        cols = {c["name"]: c for c in feature["columns"]}
+        assert cols["transition_temp"]["format"] == "float"
+        assert cols["transition_temp"]["unit"] == "°C"
+        assert cols["transition_temp"]["description"] == "Ductile-brittle transition"
+        assert cols["batch"] == {"name": "batch", "type": "text"}

--- a/server/tests/integration/test_manifest_enrichment_postgres.py
+++ b/server/tests/integration/test_manifest_enrichment_postgres.py
@@ -34,6 +34,7 @@ from osa.infrastructure.persistence.repository.schema import (
 from osa.infrastructure.persistence.tables import conventions_table
 
 from tests.integration.conftest import seed_hook_run
+from tests.factories import make_convention_docs_dict
 
 os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
 os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-integration-tests-minimum-32-chars")
@@ -100,6 +101,7 @@ async def _seed(engine: AsyncEngine, session: AsyncSession) -> None:
             file_requirements={},
             hooks=[HOOK],
             source=None,
+            docs=make_convention_docs_dict(),
             created_at=datetime.now(UTC),
         )
     )

--- a/server/tests/integration/test_skill_read_store_postgres.py
+++ b/server/tests/integration/test_skill_read_store_postgres.py
@@ -1,0 +1,194 @@
+"""Integration tests for the skill read-store projections against real Postgres (#151, US1).
+
+``get_author_docs`` projects ``conventions.docs`` by schema id (latest deploy
+wins; ``None`` only when no owning convention exists). ``sample_value``
+returns one non-null value per research §9 (identifier-quoted, schema-scoped)
+and ``None`` on an empty column.
+
+Skips automatically unless OSA_DATABASE__URL points at PostgreSQL.
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from osa.domain.semantics.model.schema import Schema
+from osa.domain.semantics.model.value import Cardinality, FieldDefinition, FieldType
+from osa.domain.shared.error import ConflictError
+from osa.domain.shared.model.hook import ColumnDef
+from osa.domain.shared.model.srn import Domain, RecordSRN, SchemaId
+from osa.infrastructure.data.postgres_catalog_read_store import PostgresCatalogReadStore
+from osa.infrastructure.persistence.feature_store import PostgresFeatureStore
+from osa.infrastructure.persistence.metadata_store import PostgresMetadataStore
+from osa.infrastructure.persistence.repository.schema import (
+    PostgresSemanticsSchemaRepository,
+)
+from osa.infrastructure.persistence.tables import conventions_table
+
+from tests.factories import make_convention_docs_dict
+from tests.integration.conftest import seed_hook_run, seed_record
+
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-integration-tests-minimum-32-chars")
+
+if "postgresql" not in os.environ.get("OSA_DATABASE__URL", ""):
+    pytest.skip("OSA_DATABASE__URL not set to PostgreSQL", allow_module_level=True)
+
+SCHEMA = SchemaId.parse("compound@1.0.0")
+HOOK = "chem_features"
+
+
+def _fields() -> list[FieldDefinition]:
+    return [
+        FieldDefinition(
+            name="species",
+            type=FieldType.TEXT,
+            required=True,
+            cardinality=Cardinality.EXACTLY_ONE,
+        ),
+        FieldDefinition(
+            name="notes",
+            type=FieldType.TEXT,
+            required=False,
+            cardinality=Cardinality.EXACTLY_ONE,
+        ),
+    ]
+
+
+async def _setup_schema(engine: AsyncEngine, session: AsyncSession) -> PostgresMetadataStore:
+    store = PostgresMetadataStore(engine, session)
+    await store.ensure_table(SCHEMA, _fields())
+    await PostgresSemanticsSchemaRepository(session).save(
+        Schema(id=SCHEMA, title="compound", fields=_fields(), created_at=datetime.now(UTC))
+    )
+    return store
+
+
+async def _insert_convention(
+    session: AsyncSession,
+    *,
+    slug: str,
+    purpose: str,
+    created_at: datetime,
+    hooks: list[str] | None = None,
+) -> None:
+    await session.execute(
+        conventions_table.insert().values(
+            id=slug,
+            title=slug,
+            description="a convention",
+            schema_id=SCHEMA.id.root,
+            schema_version=SCHEMA.version.root,
+            file_requirements={},
+            hooks=hooks or [],
+            source=None,
+            docs=make_convention_docs_dict(purpose=purpose),
+            created_at=created_at,
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+class TestGetAuthorDocs:
+    async def test_projects_convention_docs(self, pg_engine: AsyncEngine, pg_session: AsyncSession):
+        await _setup_schema(pg_engine, pg_session)
+        await _insert_convention(
+            pg_session, slug="compound-conv", purpose="Compound data.", created_at=datetime.now(UTC)
+        )
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        docs = await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root)
+        assert docs is not None
+        assert docs.purpose == "Compound data."
+        assert len(docs.examples) == 1
+
+    async def test_latest_deploy_wins(self, pg_engine: AsyncEngine, pg_session: AsyncSession):
+        await _setup_schema(pg_engine, pg_session)
+        now = datetime.now(UTC)
+        await _insert_convention(
+            pg_session,
+            slug="older-conv",
+            purpose="Old purpose.",
+            created_at=now - timedelta(days=1),
+        )
+        await _insert_convention(
+            pg_session, slug="newer-conv", purpose="New purpose.", created_at=now
+        )
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        docs = await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root)
+        assert docs is not None
+        assert docs.purpose == "New purpose."
+
+    async def test_none_when_no_owning_convention(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        await _setup_schema(pg_engine, pg_session)
+        await pg_session.commit()
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        assert await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root) is None
+
+
+@pytest.mark.asyncio
+class TestSampleValue:
+    async def _publish(self, engine, store, rid: str, metadata: dict) -> RecordSRN:
+        srn = RecordSRN.parse(f"urn:osa:localhost:rec:{rid}@1")
+        await seed_record(
+            engine,
+            srn=str(srn),
+            schema_id=SCHEMA.id.root,
+            schema_version=SCHEMA.version.root,
+            metadata=metadata,
+            published_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        await store.insert(SCHEMA, srn, metadata)
+        return srn
+
+    async def test_samples_records_column(self, pg_engine: AsyncEngine, pg_session: AsyncSession):
+        store = await _setup_schema(pg_engine, pg_session)
+        await self._publish(pg_engine, store, "rec1", {"species": "Homo sapiens"})
+        await pg_session.commit()
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        sample = await rs.sample_value(SCHEMA, "records", "species")
+        assert sample is not None
+        assert sample.value == "Homo sapiens"
+
+    async def test_none_on_empty_column(self, pg_engine: AsyncEngine, pg_session: AsyncSession):
+        store = await _setup_schema(pg_engine, pg_session)
+        await self._publish(pg_engine, store, "rec1", {"species": "Homo sapiens"})
+        await pg_session.commit()
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        assert await rs.sample_value(SCHEMA, "records", "notes") is None
+
+    async def test_none_on_empty_table(self, pg_engine: AsyncEngine, pg_session: AsyncSession):
+        await _setup_schema(pg_engine, pg_session)
+        await pg_session.commit()
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        assert await rs.sample_value(SCHEMA, "records", "species") is None
+
+    async def test_samples_feature_table_column(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        store = await _setup_schema(pg_engine, pg_session)
+        srn = await self._publish(pg_engine, store, "rec1", {"species": "Homo sapiens"})
+        # The schema → feature link goes through a convention's hooks list.
+        await _insert_convention(
+            pg_session,
+            slug="compound-conv",
+            purpose="Compound data.",
+            created_at=datetime.now(UTC),
+            hooks=[HOOK],
+        )
+        columns = [ColumnDef(name="score", json_type="number", required=True)]
+        run_id = await seed_hook_run(pg_engine, feature_name=HOOK, columns=columns)
+        feature_store = PostgresFeatureStore(pg_engine, pg_session)
+        try:
+            await feature_store.create_table(HOOK, columns)
+        except ConflictError:
+            pass
+        await feature_store.insert_features(HOOK, str(srn), [{"score": 0.9}], run_id)
+
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        sample = await rs.sample_value(SCHEMA, HOOK, "score")
+        assert sample is not None
+        assert sample.value == 0.9

--- a/server/tests/integration/test_skill_read_store_postgres.py
+++ b/server/tests/integration/test_skill_read_store_postgres.py
@@ -98,7 +98,7 @@ class TestGetAuthorDocs:
             pg_session, slug="compound-conv", purpose="Compound data.", created_at=datetime.now(UTC)
         )
         rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
-        docs = await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root)
+        docs = await rs.get_author_docs(SCHEMA)
         assert docs is not None
         assert docs.purpose == "Compound data."
         assert len(docs.examples) == 1
@@ -116,7 +116,7 @@ class TestGetAuthorDocs:
             pg_session, slug="newer-conv", purpose="New purpose.", created_at=now
         )
         rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
-        docs = await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root)
+        docs = await rs.get_author_docs(SCHEMA)
         assert docs is not None
         assert docs.purpose == "New purpose."
 
@@ -126,7 +126,7 @@ class TestGetAuthorDocs:
         await _setup_schema(pg_engine, pg_session)
         await pg_session.commit()
         rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
-        assert await rs.get_author_docs(SCHEMA.id.root, SCHEMA.version.root) is None
+        assert await rs.get_author_docs(SCHEMA) is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_skill_surface_postgres.py
+++ b/server/tests/integration/test_skill_surface_postgres.py
@@ -146,6 +146,9 @@ class TestSchemaReference:
         assert "Compound reference data." in ref.text
         # Sampled value reaches the FilterExpr example (research §9).
         assert '"value": "Homo sapiens"' in ref.text
+        # Example URLs are pinned to the documented version — a bare id would
+        # silently resolve to latest and drift from the doc being read.
+        assert "/api/v1/data/compound@1.0.0/records.csv.gz" in ref.text
         # Route-ordering regression: the JSON manifest still resolves.
         assert manifest.status_code == 200
         assert manifest.json()["id"] == "compound"

--- a/server/tests/integration/test_skill_surface_postgres.py
+++ b/server/tests/integration/test_skill_surface_postgres.py
@@ -121,7 +121,7 @@ class TestSkillDocument:
         assert resp.headers["content-type"].startswith("text/markdown")
         body = resp.text
         assert body.startswith("---\nname: osa-data-localhost\n")
-        assert "| compound@1.0.0 | Compounds | 1 | api/v1/data/compound.md |" in body
+        assert "| compound@1.0.0 | Compounds | 1 | api/v1/data/compound@1.0.0.md |" in body
         assert "Compound reference data." in body
 
     async def test_zero_schema_skill_md(self, pg_session, client: AsyncClient):

--- a/server/tests/integration/test_skill_surface_postgres.py
+++ b/server/tests/integration/test_skill_surface_postgres.py
@@ -1,0 +1,171 @@
+"""End-to-end HTTP tests for the skill surface against real Postgres (#151, US1/US4).
+
+Drives ``GET /``, ``GET /SKILL.md``, and ``GET /api/v1/data/{schema}.md``
+through the full stack, including the degraded states (zero-schema node,
+orphan schema, unknown reference ids).
+
+Skips automatically unless OSA_DATABASE__URL points at PostgreSQL.
+"""
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from osa.domain.semantics.model.schema import Schema
+from osa.domain.semantics.model.value import Cardinality, FieldDefinition, FieldType
+from osa.domain.shared.model.srn import RecordSRN, SchemaId
+from osa.infrastructure.persistence.metadata_store import PostgresMetadataStore
+from osa.infrastructure.persistence.repository.schema import (
+    PostgresSemanticsSchemaRepository,
+)
+from osa.infrastructure.persistence.tables import conventions_table
+
+from tests.factories import make_convention_docs_dict
+from tests.integration.conftest import seed_record
+
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-integration-tests-minimum-32-chars")
+
+if "postgresql" not in os.environ.get("OSA_DATABASE__URL", ""):
+    pytest.skip("OSA_DATABASE__URL not set to PostgreSQL", allow_module_level=True)
+
+SCHEMA = SchemaId.parse("compound@1.0.0")
+
+
+def _fields() -> list[FieldDefinition]:
+    return [
+        FieldDefinition(
+            name="species",
+            type=FieldType.TEXT,
+            required=True,
+            cardinality=Cardinality.EXACTLY_ONE,
+        ),
+    ]
+
+
+async def _seed_documented_schema(engine: AsyncEngine, session: AsyncSession) -> None:
+    store = PostgresMetadataStore(engine, session)
+    await store.ensure_table(SCHEMA, _fields())
+    await PostgresSemanticsSchemaRepository(session).save(
+        Schema(id=SCHEMA, title="Compounds", fields=_fields(), created_at=datetime.now(UTC))
+    )
+    await session.execute(
+        conventions_table.insert().values(
+            id="compound-conv",
+            title="Compound Conv",
+            description="compound convention",
+            schema_id=SCHEMA.id.root,
+            schema_version=SCHEMA.version.root,
+            file_requirements={},
+            hooks=[],
+            source=None,
+            docs=make_convention_docs_dict(purpose="Compound reference data."),
+            created_at=datetime.now(UTC),
+        )
+    )
+    srn = RecordSRN.parse("urn:osa:localhost:rec:rec1@1")
+    await seed_record(
+        engine,
+        srn=str(srn),
+        schema_id=SCHEMA.id.root,
+        schema_version=SCHEMA.version.root,
+        metadata={"species": "Homo sapiens"},
+        published_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    await store.insert(SCHEMA, srn, {"species": "Homo sapiens"})
+    await session.commit()
+
+
+@pytest.fixture
+def client() -> AsyncClient:
+    from osa.application.api.rest.app import create_app
+
+    return AsyncClient(transport=ASGITransport(app=create_app()), base_url="http://test")
+
+
+@pytest.mark.asyncio
+class TestRootDiscovery:
+    async def test_shape(self, pg_engine, pg_session, client: AsyncClient):
+        await _seed_documented_schema(pg_engine, pg_session)
+        async with client:
+            resp = await client.get("/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["node"]["name"] == "Open Science Archive"
+        assert body["node"]["domain"] == "localhost"
+        assert body["node"]["osa_version"]
+        assert body["skill_url"] == "http://localhost:8000/SKILL.md"
+        assert body["reference_base"] == "http://localhost:8000/api/v1/data/"
+        assert body["data_url"] == "http://localhost:8000/api/v1/data"
+        # openapi_url reflects the app's ACTUAL OpenAPI path (default /openapi.json).
+        assert body["openapi_url"] == "http://localhost:8000/openapi.json"
+        assert body["schemas"] == ["compound@1.0.0"]
+
+    async def test_zero_schemas_never_404s(self, pg_session, client: AsyncClient):
+        async with client:
+            resp = await client.get("/")
+        assert resp.status_code == 200
+        assert resp.json()["schemas"] == []
+
+
+@pytest.mark.asyncio
+class TestSkillDocument:
+    async def test_skill_md(self, pg_engine, pg_session, client: AsyncClient):
+        await _seed_documented_schema(pg_engine, pg_session)
+        async with client:
+            resp = await client.get("/SKILL.md")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/markdown")
+        body = resp.text
+        assert body.startswith("---\nname: osa-data-localhost\n")
+        assert "| compound@1.0.0 | Compounds | 1 | api/v1/data/compound.md |" in body
+        assert "Compound reference data." in body
+
+    async def test_zero_schema_skill_md(self, pg_session, client: AsyncClient):
+        async with client:
+            resp = await client.get("/SKILL.md")
+        assert resp.status_code == 200
+        assert "No datasets yet." in resp.text
+
+
+@pytest.mark.asyncio
+class TestSchemaReference:
+    async def test_reference_markdown_and_manifest_json_coexist(
+        self, pg_engine, pg_session, client: AsyncClient
+    ):
+        await _seed_documented_schema(pg_engine, pg_session)
+        async with client:
+            ref = await client.get("/api/v1/data/compound.md")
+            manifest = await client.get("/api/v1/data/compound")
+        assert ref.status_code == 200
+        assert ref.headers["content-type"].startswith("text/markdown")
+        assert ref.text.startswith("# Compounds (compound@1.0.0)")
+        assert "Compound reference data." in ref.text
+        # Sampled value reaches the FilterExpr example (research §9).
+        assert '"value": "Homo sapiens"' in ref.text
+        # Route-ordering regression: the JSON manifest still resolves.
+        assert manifest.status_code == 200
+        assert manifest.json()["id"] == "compound"
+
+    async def test_orphan_schema_renders_no_docs_note(
+        self, pg_engine, pg_session, client: AsyncClient
+    ):
+        store = PostgresMetadataStore(pg_engine, pg_session)
+        await store.ensure_table(SCHEMA, _fields())
+        await PostgresSemanticsSchemaRepository(pg_session).save(
+            Schema(id=SCHEMA, title="Compounds", fields=_fields(), created_at=datetime.now(UTC))
+        )
+        await pg_session.commit()
+        async with client:
+            resp = await client.get("/api/v1/data/compound.md")
+        assert resp.status_code == 200
+        assert "> No author documentation exists for this dataset." in resp.text
+        assert "## Worked examples" not in resp.text
+
+    async def test_unknown_schema_404(self, pg_session, client: AsyncClient):
+        async with client:
+            resp = await client.get("/api/v1/data/unknown.md")
+        assert resp.status_code == 404

--- a/server/tests/unit/domain/data/test_data_catalog_service.py
+++ b/server/tests/unit/domain/data/test_data_catalog_service.py
@@ -38,6 +38,7 @@ MANIFEST = SchemaManifest(
     id="compound",
     version="1.0.0",
     srn="urn:osa:localhost:schema:compound@1.0.0",
+    title="compound",
     fields=[],
     table_resources=[
         TableResource(

--- a/server/tests/unit/domain/data/test_skill_renderer_degradation.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_degradation.py
@@ -89,9 +89,7 @@ class TestOrphanSchema:
         assert "## When not to use" not in out
 
     def test_orphan_schema_still_in_datasets_table(self) -> None:
-        ds = DatasetEntry(
-            schema_id="orphan", schema_ref="orphan@1.0.0", title="Orphan Records", row_count=0
-        )
+        ds = DatasetEntry(schema_ref="orphan@1.0.0", title="Orphan Records", row_count=0)
         out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
         assert "| orphan@1.0.0 |" in out
 

--- a/server/tests/unit/domain/data/test_skill_renderer_degradation.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_degradation.py
@@ -35,7 +35,7 @@ def _manifest_no_features() -> SchemaManifest:
         id="orphan",
         version="1.0.0",
         srn="urn:osa:localhost:schema:orphan@1.0.0",
-        title=None,
+        title="Orphan Records",
         fields=[FieldSpec(name="species", type=FieldType.TEXT)],
         table_resources=[
             TableResource(
@@ -89,7 +89,9 @@ class TestOrphanSchema:
         assert "## When not to use" not in out
 
     def test_orphan_schema_still_in_datasets_table(self) -> None:
-        ds = DatasetEntry(schema_id="orphan", schema_ref="orphan@1.0.0", title=None, row_count=0)
+        ds = DatasetEntry(
+            schema_id="orphan", schema_ref="orphan@1.0.0", title="Orphan Records", row_count=0
+        )
         out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
         assert "| orphan@1.0.0 |" in out
 

--- a/server/tests/unit/domain/data/test_skill_renderer_degradation.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_degradation.py
@@ -1,0 +1,114 @@
+"""Renderer degradation tests (#151, US4) — degraded, never broken.
+
+Empty catalog, schema without feature tables, orphan schema (no owning
+convention → ``docs is None``), and empty-column sampling all render valid
+documents (FR-021..023).
+"""
+
+from osa.domain.data.model.manifest import (
+    IMPLICIT_RECORD_COLUMN_SPECS,
+    ColumnSpec,
+    FieldSpec,
+    SchemaManifest,
+    TableResource,
+)
+from osa.domain.data.model.query_plan import TableKind
+from osa.domain.data.model.skill import DatasetEntry, NodeIdentity
+from osa.domain.data.service.skill_renderer import SkillRenderer
+
+BASE = "http://localhost:8000"
+
+
+def _node() -> NodeIdentity:
+    return NodeIdentity(
+        name="Open Science Archive",
+        domain="localhost",
+        description="An open platform.",
+        osa_version="0.0.5",
+    )
+
+
+def _manifest_no_features() -> SchemaManifest:
+    from osa.domain.semantics.model.value import FieldType
+
+    return SchemaManifest(
+        id="orphan",
+        version="1.0.0",
+        srn="urn:osa:localhost:schema:orphan@1.0.0",
+        title=None,
+        fields=[FieldSpec(name="species", type=FieldType.TEXT)],
+        table_resources=[
+            TableResource(
+                name="records",
+                kind=TableKind.RECORDS,
+                columns=[
+                    *IMPLICIT_RECORD_COLUMN_SPECS,
+                    ColumnSpec(name="species", type=FieldType.TEXT),
+                ],
+                row_count=0,
+                formats=["", "csv", "csv.gz"],
+            )
+        ],
+    )
+
+
+class TestEmptyNodeSkill:
+    def test_zero_schemas_renders_valid_document_with_note(self) -> None:
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[], docs=[])
+        assert out.startswith("---\nname: osa-data-localhost\n")
+        assert "## Datasets" in out
+        assert "No datasets yet." in out
+        # No dataset rows
+        assert "api/v1/data/" not in out.split("## Access")[0].split("## Datasets")[1]
+
+
+class TestSchemaWithoutFeatureTables:
+    def test_feature_section_omitted_entirely(self) -> None:
+        out = SkillRenderer().render_reference(
+            manifest=_manifest_no_features(),
+            docs=None,
+            base_url=BASE,
+            sample_field="species",
+            sample=None,
+        )
+        assert "## Feature tables" not in out
+        assert "## Records table" in out
+
+
+class TestOrphanSchema:
+    def test_no_docs_note_and_sections_omitted(self) -> None:
+        out = SkillRenderer().render_reference(
+            manifest=_manifest_no_features(),
+            docs=None,
+            base_url=BASE,
+            sample_field="species",
+            sample=None,
+        )
+        assert "> No author documentation exists for this dataset." in out
+        assert "## Worked examples" not in out
+        assert "## When not to use" not in out
+
+    def test_orphan_schema_still_in_datasets_table(self) -> None:
+        ds = DatasetEntry(schema_id="orphan", schema_ref="orphan@1.0.0", title=None, row_count=0)
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
+        assert "| orphan@1.0.0 |" in out
+
+
+class TestEmptyColumnSampling:
+    def test_placeholder_when_sample_is_none(self) -> None:
+        out = SkillRenderer().render_reference(
+            manifest=_manifest_no_features(),
+            docs=None,
+            base_url=BASE,
+            sample_field="species",
+            sample=None,
+        )
+        assert '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
+
+    def test_examples_still_render_without_any_field(self) -> None:
+        manifest = _manifest_no_features().model_copy(update={"fields": []})
+        out = SkillRenderer().render_reference(
+            manifest=manifest, docs=None, base_url=BASE, sample_field=None, sample=None
+        )
+        assert "## Examples" in out
+        assert "records.csv.gz" in out

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -172,10 +172,13 @@ class TestMechanicalExamples:
         out = _render()
         examples = out[out.index("## Examples") :]
         assert examples.index("records.csv.gz") < examples.index("FilterExpr")
-        assert f"GET {BASE}/api/v1/data/alloy-tests/records.csv.gz" in examples
+        # Versioned, so the example targets exactly the documented schema version
+        # even when a newer latest exists (review: versioned-examples drift).
+        assert f"GET {BASE}/api/v1/data/alloy-tests@2.1.0/records.csv.gz" in examples
 
     def test_filter_example_uses_sampled_value_and_actual_field(self) -> None:
         out = _render()
+        assert f"POST {BASE}/api/v1/data/alloy-tests@2.1.0/records" in out
         assert (
             '{"filter": {"kind": "predicate", "field": "metadata.yield_strength", '
             '"op": "eq", "value": 512}}'
@@ -187,7 +190,7 @@ class TestMechanicalExamples:
 
     def test_join_recipe_spells_out_columns(self) -> None:
         out = _render()
-        assert f"GET {BASE}/api/v1/data/alloy-tests/ductility.csv.gz" in out
+        assert f"GET {BASE}/api/v1/data/alloy-tests@2.1.0/ductility.csv.gz" in out
         assert "`ductility.record_srn`" in out
 
     def test_single_record_fetch(self) -> None:

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -1,0 +1,213 @@
+"""SkillRenderer reference-doc exact-output tests (#151, US1).
+
+The reference doc is the markdown representation of the schema resource:
+records field table (implicit columns first), one subsection per feature
+table, join keys + provenance chain, mechanical examples templated with
+actual field/feature names (sampled value when available), and author
+worked examples rendered verbatim (FR-018).
+"""
+
+from osa.domain.data.model.manifest import (
+    IMPLICIT_FEATURE_COLUMN_SPECS,
+    IMPLICIT_RECORD_COLUMN_SPECS,
+    ColumnSpec,
+    FieldSpec,
+    SchemaManifest,
+    TableResource,
+)
+from osa.domain.data.model.query_plan import TableKind
+from osa.domain.data.model.skill import AuthorDocs, ExampleDoc, SampleValue
+from osa.domain.data.service.skill_renderer import SkillRenderer
+from osa.domain.semantics.model.value import FieldType
+
+BASE = "https://archive.university.edu"
+
+
+def _fields() -> list[FieldSpec]:
+    return [
+        FieldSpec(
+            name="yield_strength",
+            type=FieldType.NUMBER,
+            description="0.2% offset yield strength",
+            unit="MPa",
+            examples=["512"],
+        ),
+        FieldSpec(
+            name="tissue",
+            type=FieldType.TERM,
+            ontology_id="uberon",
+            ontology_version="2025-01-15",
+        ),
+    ]
+
+
+def _manifest(*, with_feature: bool = True) -> SchemaManifest:
+    resources = [
+        TableResource(
+            name="records",
+            kind=TableKind.RECORDS,
+            columns=[
+                *IMPLICIT_RECORD_COLUMN_SPECS,
+                ColumnSpec(name="yield_strength", type=FieldType.NUMBER),
+                ColumnSpec(name="tissue", type=FieldType.TERM),
+            ],
+            row_count=12480,
+            formats=["", "csv", "csv.gz"],
+        )
+    ]
+    if with_feature:
+        resources.append(
+            TableResource(
+                name="ductility",
+                kind=TableKind.FEATURE,
+                columns=[
+                    *IMPLICIT_FEATURE_COLUMN_SPECS,
+                    ColumnSpec(
+                        name="transition_temp",
+                        type=FieldType.NUMBER,
+                        format="float",
+                        unit="°C",
+                        description="Ductile-brittle transition",
+                    ),
+                ],
+                row_count=9312,
+                formats=["", "csv", "csv.gz"],
+            )
+        )
+    return SchemaManifest(
+        id="alloy-tests",
+        version="2.1.0",
+        srn="urn:osa:archive.university.edu:schema:alloy-tests@2.1.0",
+        title="Alloy Ductility Tests",
+        fields=_fields(),
+        table_resources=resources,
+    )
+
+
+def _docs() -> AuthorDocs:
+    return AuthorDocs(
+        purpose="Test-campaign results for structural alloys.",
+        example_questions=["q1?", "q2?", "q3?"],
+        examples=[
+            ExampleDoc(
+                question="Which alloys stay ductile below -40C?",
+                query='POST /api/v1/data/alloy-tests/records {"filter": {"kind": "predicate", "field": "features.ductility.transition_temp", "op": "lt", "value": -40}}',
+                interpretation="Rows are individual test coupons.",
+            )
+        ],
+    )
+
+
+def _render(**overrides: object) -> str:
+    kwargs: dict = {
+        "manifest": _manifest(),
+        "docs": _docs(),
+        "base_url": BASE,
+        "sample_field": "yield_strength",
+        "sample": SampleValue(value=512),
+    }
+    kwargs.update(overrides)
+    return SkillRenderer().render_reference(**kwargs)
+
+
+class TestReferenceHeader:
+    def test_header_line(self) -> None:
+        assert _render().startswith("# Alloy Ductility Tests (alloy-tests@2.1.0)\n")
+
+    def test_header_falls_back_to_id_without_title(self) -> None:
+        manifest = _manifest()
+        manifest = manifest.model_copy(update={"title": None})
+        out = _render(manifest=manifest)
+        assert out.startswith("# alloy-tests (alloy-tests@2.1.0)\n")
+
+    def test_purpose_paragraph_when_docs_exist(self) -> None:
+        assert "\nTest-campaign results for structural alloys.\n" in _render()
+
+
+class TestRecordsTable:
+    def test_implicit_columns_documented_first(self) -> None:
+        out = _render()
+        table_start = out.index("## Records table")
+        rows = [line for line in out[table_start:].split("\n") if line.startswith("| ")]
+        # header + separator are not "| " prefixed with names — collect first cells
+        first_cells = [r.split("|")[1].strip() for r in rows]
+        implicit = ["id", "srn", "schema_id", "version", "created_at"]
+        names = [c for c in first_cells if c not in ("Column", "---")]
+        assert names[:5] == implicit
+
+    def test_field_row_carries_unit_description_examples(self) -> None:
+        assert (
+            "| yield_strength | number | MPa | 0.2% offset yield strength |  | 512 |" in _render()
+        )
+
+    def test_term_field_carries_ontology_ref(self) -> None:
+        assert "| tissue | term |  |  | uberon@2025-01-15 |  |" in _render()
+
+
+class TestFeatureTables:
+    def test_feature_subsection_with_column_metadata(self) -> None:
+        out = _render()
+        assert "## Feature tables" in out
+        assert "### ductility" in out
+        assert "| transition_temp | number | float | °C | Ductile-brittle transition |" in out
+
+    def test_implicit_feature_columns_listed(self) -> None:
+        out = _render()
+        feature_start = out.index("### ductility")
+        assert "| record_srn | text |" in out[feature_start:]
+
+
+class TestJoinKeysAndProvenance:
+    def test_join_keys(self) -> None:
+        out = _render()
+        assert "## Join keys & provenance" in out
+        assert "`record_srn`" in out
+        assert "`records.srn`" in out
+        assert "`records.id`" in out
+
+    def test_provenance_chain(self) -> None:
+        out = _render()
+        assert "`run_id`" in out
+        assert "hook_run" in out
+        assert "hook_release" in out
+        assert "source_ref" in out
+
+
+class TestMechanicalExamples:
+    def test_bulk_dump_leads(self) -> None:
+        out = _render()
+        examples = out[out.index("## Examples") :]
+        assert examples.index("records.csv.gz") < examples.index("FilterExpr")
+        assert f"GET {BASE}/api/v1/data/alloy-tests/records.csv.gz" in examples
+
+    def test_filter_example_uses_sampled_value_and_actual_field(self) -> None:
+        out = _render()
+        assert (
+            '{"filter": {"kind": "predicate", "field": "metadata.yield_strength", '
+            '"op": "eq", "value": 512}}'
+        ) in out
+
+    def test_filter_example_placeholder_when_no_sample(self) -> None:
+        out = _render(sample=None)
+        assert '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
+
+    def test_join_recipe_spells_out_columns(self) -> None:
+        out = _render()
+        assert f"GET {BASE}/api/v1/data/alloy-tests/ductility.csv.gz" in out
+        assert "`ductility.record_srn`" in out
+
+    def test_single_record_fetch(self) -> None:
+        assert f"GET {BASE}/api/v1/data/records/<id>" in _render()
+
+
+class TestWorkedExamples:
+    def test_rendered_verbatim(self) -> None:
+        out = _render()
+        assert "## Worked examples" in out
+        assert "### Which alloys stay ductile below -40C?" in out
+        # The query string appears byte-for-byte (FR-018) — never rewritten.
+        assert (
+            'POST /api/v1/data/alloy-tests/records {"filter": {"kind": "predicate", '
+            '"field": "features.ductility.transition_temp", "op": "lt", "value": -40}}'
+        ) in out
+        assert "Rows are individual test coupons." in out

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -114,12 +114,6 @@ class TestReferenceHeader:
     def test_header_line(self) -> None:
         assert _render().startswith("# Alloy Ductility Tests (alloy-tests@2.1.0)\n")
 
-    def test_header_falls_back_to_id_without_title(self) -> None:
-        manifest = _manifest()
-        manifest = manifest.model_copy(update={"title": None})
-        out = _render(manifest=manifest)
-        assert out.startswith("# alloy-tests (alloy-tests@2.1.0)\n")
-
     def test_purpose_paragraph_when_docs_exist(self) -> None:
         assert "\nTest-campaign results for structural alloys.\n" in _render()
 

--- a/server/tests/unit/domain/data/test_skill_renderer_skill.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_skill.py
@@ -126,11 +126,6 @@ class TestRenderSkillParts:
         assert "questions like: q1? q2?\n" in out
         assert out.count("q1?") == 1
 
-    def test_dataset_without_title_renders_empty_cell(self) -> None:
-        ds = DatasetEntry(schema_id="orphan", schema_ref="orphan@1.0.0", title=None, row_count=0)
-        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
-        assert "| orphan@1.0.0 |  | 0 | api/v1/data/orphan.md |" in out
-
     def test_when_not_to_use_omitted_without_author_content(self) -> None:
         out = SkillRenderer().render_skill(
             node=_node(), base_url=BASE, datasets=[_dataset()], docs=[]
@@ -141,6 +136,6 @@ class TestRenderSkillParts:
     def test_reference_links_are_percent_encoded(self) -> None:
         # Schema ids can never contain spaces, but the renderer encodes
         # defensively (research §11 belt-and-braces).
-        ds = DatasetEntry(schema_id="a b", schema_ref="a b@1.0.0", title=None, row_count=0)
+        ds = DatasetEntry(schema_id="a b", schema_ref="a b@1.0.0", title="A B", row_count=0)
         out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
         assert "api/v1/data/a%20b.md" in out

--- a/server/tests/unit/domain/data/test_skill_renderer_skill.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_skill.py
@@ -45,7 +45,6 @@ def _docs() -> AuthorDocs:
 
 def _dataset() -> DatasetEntry:
     return DatasetEntry(
-        schema_id="alloy-tests",
         schema_ref="alloy-tests@2.1.0",
         title="Alloy Ductility Tests",
         row_count=12480,
@@ -89,7 +88,7 @@ Test-campaign results for structural alloys.
 
 | Schema | Title | Records | Reference |
 |---|---|---|---|
-| alloy-tests@2.1.0 | Alloy Ductility Tests | 12480 | api/v1/data/alloy-tests.md |
+| alloy-tests@2.1.0 | Alloy Ductility Tests | 12480 | api/v1/data/alloy-tests@2.1.0.md |
 
 ## Access
 
@@ -135,7 +134,18 @@ class TestRenderSkillParts:
 
     def test_reference_links_are_percent_encoded(self) -> None:
         # Schema ids can never contain spaces, but the renderer encodes
-        # defensively (research §11 belt-and-braces).
-        ds = DatasetEntry(schema_id="a b", schema_ref="a b@1.0.0", title="A B", row_count=0)
+        # defensively (research §11 belt-and-braces). The `@` stays literal —
+        # it is valid in a path segment and the versioned form must stay
+        # copy-pasteable for agents.
+        ds = DatasetEntry(schema_ref="a b@1.0.0", title="A B", row_count=0)
         out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
-        assert "api/v1/data/a%20b.md" in out
+        assert "api/v1/data/a%20b@1.0.0.md" in out
+
+    def test_reference_links_pin_the_documented_version(self) -> None:
+        # A bare-id link resolves to *latest*, so an older schema version's
+        # row would point at incompatible docs (review: pinned-links drift).
+        out = SkillRenderer().render_skill(
+            node=_node(), base_url=BASE, datasets=[_dataset()], docs=[]
+        )
+        assert "api/v1/data/alloy-tests@2.1.0.md" in out
+        assert "api/v1/data/alloy-tests.md" not in out

--- a/server/tests/unit/domain/data/test_skill_renderer_skill.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_skill.py
@@ -1,0 +1,146 @@
+"""SkillRenderer SKILL.md exact-output tests (#151, US1).
+
+Pure renderer — string in/out, no I/O. The frontmatter name is
+``osa-data-<sanitized-domain>`` (lowercase, non-[a-z0-9] → '-', runs
+collapsed); the description joins the node description with the distinct
+trigger-question union; the datasets table carries live counts and
+root-relative reference links.
+"""
+
+from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, ExampleDoc, NodeIdentity
+from osa.domain.data.service.skill_renderer import SkillRenderer, sanitize_skill_name
+
+BASE = "https://archive.university.edu"
+
+
+def _node(**overrides: object) -> NodeIdentity:
+    kwargs: dict = {
+        "name": "Open Science Archive",
+        "domain": "archive.university.edu",
+        "description": "An open platform for depositing scientific data.",
+        "osa_version": "0.0.5",
+    }
+    kwargs.update(overrides)
+    return NodeIdentity.model_validate(kwargs)
+
+
+def _docs() -> AuthorDocs:
+    return AuthorDocs(
+        purpose="Test-campaign results for structural alloys.",
+        example_questions=[
+            "Which alloys stay ductile below -40C?",
+            "What is the yield strength range?",
+        ],
+        examples=[
+            ExampleDoc(
+                question="Which samples have corrosion panels attached?",
+                query="GET /x",
+                interpretation="means x",
+            )
+        ],
+        when_not_to_use="Not a materials-property database.",
+        see_also=["https://other-node.example.org"],
+    )
+
+
+def _dataset() -> DatasetEntry:
+    return DatasetEntry(
+        schema_id="alloy-tests",
+        schema_ref="alloy-tests@2.1.0",
+        title="Alloy Ductility Tests",
+        row_count=12480,
+    )
+
+
+class TestSanitizeSkillName:
+    def test_domain_dots_become_dashes(self) -> None:
+        assert sanitize_skill_name("archive.university.edu") == "osa-data-archive-university-edu"
+
+    def test_lowercases(self) -> None:
+        assert sanitize_skill_name("ARCHIVE.University.EDU") == "osa-data-archive-university-edu"
+
+    def test_collapses_runs(self) -> None:
+        assert sanitize_skill_name("a..b__c") == "osa-data-a-b-c"
+
+    def test_localhost(self) -> None:
+        assert sanitize_skill_name("localhost") == "osa-data-localhost"
+
+
+class TestRenderSkillExact:
+    def test_full_document(self) -> None:
+        renderer = SkillRenderer()
+        out = renderer.render_skill(
+            node=_node(),
+            base_url=BASE,
+            datasets=[_dataset()],
+            docs=[_docs()],
+        )
+        expected = """\
+---
+name: osa-data-archive-university-edu
+description: An open platform for depositing scientific data. Use when answering questions like: Which alloys stay ductile below -40C? What is the yield strength range? Which samples have corrosion panels attached?
+---
+
+# Open Science Archive
+
+Test-campaign results for structural alloys.
+
+## Datasets
+
+| Schema | Title | Records | Reference |
+|---|---|---|---|
+| alloy-tests@2.1.0 | Alloy Ductility Tests | 12480 | api/v1/data/alloy-tests.md |
+
+## Access
+
+- Bulk:   GET  https://archive.university.edu/api/v1/data/<schema>/records.csv.gz
+- Filter: POST https://archive.university.edu/api/v1/data/<schema>/records (FilterExpr body — use for large tables)
+- One:    GET  https://archive.university.edu/api/v1/data/records/<id>
+
+## When not to use
+
+Not a materials-property database.
+
+## See also
+
+- https://other-node.example.org
+"""
+        assert out == expected
+
+
+class TestRenderSkillParts:
+    def test_description_without_docs_is_node_description_alone(self) -> None:
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[], docs=[])
+        assert "description: An open platform for depositing scientific data.\n" in out
+        assert "Use when answering questions like" not in out
+
+    def test_trigger_questions_are_distinct_across_sources(self) -> None:
+        docs = AuthorDocs(
+            purpose="p",
+            example_questions=["q1?", "q2?"],
+            examples=[ExampleDoc(question="q1?", query="x", interpretation="y")],
+        )
+        out = SkillRenderer().render_skill(
+            node=_node(), base_url=BASE, datasets=[_dataset()], docs=[docs]
+        )
+        assert "questions like: q1? q2?\n" in out
+        assert out.count("q1?") == 1
+
+    def test_dataset_without_title_renders_empty_cell(self) -> None:
+        ds = DatasetEntry(schema_id="orphan", schema_ref="orphan@1.0.0", title=None, row_count=0)
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
+        assert "| orphan@1.0.0 |  | 0 | api/v1/data/orphan.md |" in out
+
+    def test_when_not_to_use_omitted_without_author_content(self) -> None:
+        out = SkillRenderer().render_skill(
+            node=_node(), base_url=BASE, datasets=[_dataset()], docs=[]
+        )
+        assert "## When not to use" not in out
+        assert "## See also" not in out
+
+    def test_reference_links_are_percent_encoded(self) -> None:
+        # Schema ids can never contain spaces, but the renderer encodes
+        # defensively (research §11 belt-and-braces).
+        ds = DatasetEntry(schema_id="a b", schema_ref="a b@1.0.0", title=None, row_count=0)
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
+        assert "api/v1/data/a%20b.md" in out

--- a/server/tests/unit/domain/deposition/test_convention.py
+++ b/server/tests/unit/domain/deposition/test_convention.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from osa.domain.deposition.model.convention import Convention
 from osa.domain.deposition.model.value import FileRequirements
 from osa.domain.shared.model.srn import ConventionSlug, SchemaId
+from tests.factories import make_convention_docs
 
 
 def _make_conv_slug(slug: str = "test-conv") -> ConventionSlug:
@@ -32,6 +33,7 @@ class TestConventionCreation:
             description="A test convention",
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         assert conv.title == "scRNA-seq Submission"
@@ -45,6 +47,7 @@ class TestConventionCreation:
             description="A test convention",
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         assert conv.description == "A test convention"
@@ -57,6 +60,7 @@ class TestConventionCreation:
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
             hooks=[],
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         assert conv.hooks == []
@@ -71,6 +75,7 @@ class TestConventionIdentity:
             description="A test convention",
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         assert conv.id.root == "my-conv"

--- a/server/tests/unit/domain/deposition/test_convention_docs.py
+++ b/server/tests/unit/domain/deposition/test_convention_docs.py
@@ -1,0 +1,121 @@
+"""Unit tests for the ``Example`` and ``ConventionDocs`` value objects (#151, US2).
+
+The VO encodes the mandatory-docs minimum itself: non-empty purpose, ≥1 worked
+example, and ≥3 distinct trigger questions across
+``example_questions ∪ {e.question for e in examples}`` — so an under-documented
+deploy cannot construct a Convention at all (FR-013..016).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from osa.domain.deposition.model.docs import ConventionDocs, Example
+
+
+def _example(question: str = "Which alloys stay ductile below -40C?") -> Example:
+    return Example(
+        question=question,
+        query='POST /api/v1/data/alloy-tests/records {"filter": {}}',
+        interpretation="Rows are individual test coupons.",
+    )
+
+
+def _docs(**overrides: object) -> ConventionDocs:
+    kwargs: dict = {
+        "purpose": "Test-campaign results for structural alloys.",
+        "example_questions": [
+            "Which alloys stay ductile below -40C?",
+            "What is the yield strength range for 7xxx-series samples?",
+            "Which samples have corrosion panels attached?",
+        ],
+        "examples": [_example()],
+    }
+    kwargs.update(overrides)
+    return ConventionDocs.model_validate(kwargs)
+
+
+class TestExample:
+    def test_valid_example(self) -> None:
+        ex = _example()
+        assert ex.question.startswith("Which alloys")
+        assert ex.query.startswith("POST ")
+        assert ex.interpretation
+
+    @pytest.mark.parametrize("field", ["question", "query", "interpretation"])
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_rejects_empty_fields(self, field: str, value: str) -> None:
+        kwargs = {
+            "question": "q?",
+            "query": "GET /x",
+            "interpretation": "means y",
+        }
+        kwargs[field] = value
+        with pytest.raises(ValidationError):
+            Example.model_validate(kwargs)
+
+
+class TestConventionDocs:
+    def test_valid_docs(self) -> None:
+        docs = _docs()
+        assert docs.purpose
+        assert len(docs.examples) == 1
+        assert docs.when_not_to_use is None
+        assert docs.see_also is None
+
+    def test_optional_fields_accepted(self) -> None:
+        docs = _docs(
+            when_not_to_use="Not a materials-property database.",
+            see_also=["https://other-node.example.org"],
+        )
+        assert docs.when_not_to_use == "Not a materials-property database."
+        assert docs.see_also == ["https://other-node.example.org"]
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_rejects_empty_purpose(self, value: str) -> None:
+        with pytest.raises(ValidationError):
+            _docs(purpose=value)
+
+    def test_rejects_zero_examples(self) -> None:
+        with pytest.raises(ValidationError):
+            _docs(examples=[])
+
+    def test_rejects_empty_example_question_entries(self) -> None:
+        with pytest.raises(ValidationError):
+            _docs(
+                example_questions=["ok question?", "   ", "another?"],
+            )
+
+    def test_worked_example_questions_count_toward_three(self) -> None:
+        # 2 trigger-only + 1 distinct worked-example question = 3 distinct.
+        docs = _docs(
+            example_questions=["q1?", "q2?"],
+            examples=[_example("q3?")],
+        )
+        assert len(docs.example_questions) == 2
+
+    def test_rejects_fewer_than_three_distinct_questions(self) -> None:
+        with pytest.raises(ValidationError, match="3"):
+            _docs(
+                example_questions=["q1?"],
+                examples=[_example("q2?")],
+            )
+
+    def test_duplicate_questions_count_once(self) -> None:
+        # The worked example repeats a trigger question — only 2 distinct.
+        with pytest.raises(ValidationError, match="3"):
+            _docs(
+                example_questions=["q1?", "q2?"],
+                examples=[_example("q1?")],
+            )
+
+    def test_examples_alone_can_supply_the_breadth(self) -> None:
+        docs = _docs(
+            example_questions=[],
+            examples=[_example("q1?"), _example("q2?"), _example("q3?")],
+        )
+        assert docs.example_questions == []
+
+    def test_round_trips_through_serialization(self) -> None:
+        docs = _docs(when_not_to_use="No.", see_also=["x"])
+        restored = ConventionDocs.model_validate(docs.model_dump(mode="json"))
+        assert restored == docs

--- a/server/tests/unit/domain/deposition/test_convention_service.py
+++ b/server/tests/unit/domain/deposition/test_convention_service.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.factories import make_convention_docs
 
 from osa.domain.deposition.model.convention import Convention
 from osa.domain.deposition.model.deploy import HookDeploy
@@ -103,6 +104,7 @@ async def _deploy(service: ConventionService, **overrides) -> Convention:
         schema_version="1.0.0",
         schema_fields=_make_field_defs(),
         hooks=None,
+        docs=make_convention_docs(),
     )
     kwargs.update(overrides)
     return await service.deploy(**kwargs)
@@ -179,6 +181,7 @@ class TestConventionServiceGet:
             description="A test convention",
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         conv_repo = AsyncMock()
@@ -207,6 +210,7 @@ class TestConventionServiceList:
             description="A test convention",
             schema_id=_make_schema_id(),
             file_requirements=_make_file_reqs(),
+            docs=make_convention_docs(),
             created_at=datetime.now(UTC),
         )
         conv_repo = AsyncMock()

--- a/server/tests/unit/domain/deposition/test_convention_service_v2.py
+++ b/server/tests/unit/domain/deposition/test_convention_service_v2.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.factories import make_convention_docs
 
 from osa.domain.deposition.event.convention_registered import ConventionRegistered
 from osa.domain.deposition.model.deploy import HookDeploy
@@ -114,6 +115,7 @@ async def _deploy(service: ConventionService, **overrides):
         schema_version="1.0.0",
         schema_fields=_make_field_defs(),
         hooks=None,
+        docs=make_convention_docs(),
     )
     kwargs.update(overrides)
     return await service.deploy(**kwargs)

--- a/server/tests/unit/domain/deposition/test_deposition_service.py
+++ b/server/tests/unit/domain/deposition/test_deposition_service.py
@@ -23,6 +23,8 @@ from osa.domain.deposition.service.deposition import DepositionService
 from osa.domain.shared.error import NotFoundError, ValidationError
 from osa.domain.shared.model.srn import ConventionSlug, DepositionSRN, Domain, SchemaId
 
+from tests.factories import make_convention_docs
+
 
 def _make_dep_srn(id: str = "test-dep") -> DepositionSRN:
     return DepositionSRN.parse(f"urn:osa:localhost:dep:{id}")
@@ -54,6 +56,7 @@ def _make_convention(**overrides) -> Convention:
         description="A test convention",
         schema_id=_make_schema_id(),
         file_requirements=_make_file_reqs(),
+        docs=make_convention_docs(),
         created_at=datetime.now(UTC),
     )
     defaults.update(overrides)

--- a/server/tests/unit/domain/record/test_record_service.py
+++ b/server/tests/unit/domain/record/test_record_service.py
@@ -23,6 +23,8 @@ from osa.domain.shared.model.srn import (
 )
 from osa.domain.shared.outbox import Outbox
 
+from tests.factories import make_convention_docs
+
 
 def _make_conv_slug() -> ConventionSlug:
     return ConventionSlug("test")
@@ -40,6 +42,7 @@ def _make_convention() -> Convention:
         schema_id=_make_schema_id(),
         file_requirements=FileRequirements(accepted_types=[], max_count=0, max_file_size=0),
         hooks=[],
+        docs=make_convention_docs(),
         created_at=datetime.now(UTC),
     )
 

--- a/server/tests/unit/domain/semantics/test_field_definition_examples.py
+++ b/server/tests/unit/domain/semantics/test_field_definition_examples.py
@@ -1,0 +1,36 @@
+"""FieldDefinition.examples — optional author-supplied representative values (#151)."""
+
+from osa.domain.semantics.model.value import Cardinality, FieldDefinition, FieldType
+
+
+def _field(**overrides: object) -> FieldDefinition:
+    kwargs: dict = {
+        "name": "yield_strength",
+        "type": FieldType.NUMBER,
+        "required": True,
+        "cardinality": Cardinality.EXACTLY_ONE,
+    }
+    kwargs.update(overrides)
+    return FieldDefinition.model_validate(kwargs)
+
+
+class TestFieldDefinitionExamples:
+    def test_examples_defaults_to_none(self) -> None:
+        field = _field()
+        assert field.examples is None
+
+    def test_examples_accepts_list_of_strings(self) -> None:
+        field = _field(examples=["512", "480"])
+        assert field.examples == ["512", "480"]
+
+    def test_examples_round_trips_through_serialization(self) -> None:
+        field = _field(examples=["512"])
+        restored = FieldDefinition.model_validate(field.model_dump())
+        assert restored == field
+        assert restored.examples == ["512"]
+
+    def test_absent_examples_round_trips_unchanged(self) -> None:
+        field = _field()
+        restored = FieldDefinition.model_validate(field.model_dump())
+        assert restored == field
+        assert restored.examples is None

--- a/server/tests/unit/domain/shared/test_column_def_metadata.py
+++ b/server/tests/unit/domain/shared/test_column_def_metadata.py
@@ -1,0 +1,37 @@
+"""ColumnDef.description/unit — optional per-column metadata on hook outputs (#151)."""
+
+from osa.domain.shared.model.hook import ColumnDef
+
+
+def _column(**overrides: object) -> ColumnDef:
+    kwargs: dict = {
+        "name": "transition_temp",
+        "json_type": "number",
+        "required": True,
+    }
+    kwargs.update(overrides)
+    return ColumnDef.model_validate(kwargs)
+
+
+class TestColumnDefMetadata:
+    def test_description_and_unit_default_to_none(self) -> None:
+        column = _column()
+        assert column.description is None
+        assert column.unit is None
+
+    def test_accepts_description_and_unit(self) -> None:
+        column = _column(description="Ductile-brittle transition", unit="°C")
+        assert column.description == "Ductile-brittle transition"
+        assert column.unit == "°C"
+
+    def test_round_trips_through_serialization(self) -> None:
+        column = _column(description="Ductile-brittle transition", unit="°C")
+        restored = ColumnDef.model_validate(column.model_dump())
+        assert restored == column
+
+    def test_absent_metadata_round_trips_unchanged(self) -> None:
+        column = _column()
+        restored = ColumnDef.model_validate(column.model_dump())
+        assert restored == column
+        assert restored.description is None
+        assert restored.unit is None

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "osa"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
Closes #151.

Makes every node self-describing to AI agents: an agent pointed at a bare domain can discover the node, load a generated skill, read per-dataset reference docs, and answer data questions grounded in real rows — with no node-specific pre-configuration.

## New surface

- **`GET /`** — root discovery document: node identity plus pointers (`skill_url`, `reference_base`, `data_url`, `openapi_url`) and the published schema list. Never 404s; zero schemas ⇒ `"schemas": []`.
- **`GET /SKILL.md`** — generated skill index: frontmatter (`name: osa-data-<sanitized-domain>`, trigger-question description), datasets table with live row counts, access patterns.
- **`GET /api/v1/data/{schema}.md`** — per-schema reference doc as the markdown representation of the schema resource (suffix convention, registered before the `/{schema}` manifest catch-all): field/feature tables, join keys, `run_id → hook_run → hook_release` provenance, mechanical examples templated with real names (one `LIMIT 1` value sample), author worked examples verbatim.

All three are public and rendered on demand from the live catalog — no cache, no read model. Rendering is a pure `SkillRenderer` fed by `SkillGeneratorService` in the `data` domain; I/O goes through two new read-store port methods (`get_author_docs`, `sample_value`).

## Mandatory author docs (deploy gate)

- `POST /conventions` now requires a `docs` block: non-empty `purpose`, ≥1 worked `Example`, and ≥3 distinct trigger questions across `example_questions` ∪ worked-example questions. Under-documented deploys are rejected with a 422 naming each gap — no bypass flag.
- Docs persist as `ConventionDocs` in a new `NOT NULL` `conventions.docs` JSONB column (edited into the squashed initial migration; `alembic check` zero-drift) and read back on `GET /conventions/{slug}`.

## Manifest enrichment (additive)

`GET /data/{schema}` now surfaces `title`, field `description`/`unit` (hoisted from `NumberConstraints.unit`)/`examples`, and feature-column `format`/`description`/`unit`. Absent attributes are omitted from serialized output (`response_model_exclude_none`), so undocumented fields carry no new keys. Also fixes a latent bug: term fields' ontology refs were read from dead dict keys and silently dropped; they now derive from `TermConstraints.ontology_srn`.

## Degradation (never broken)

Zero-schema node, schema without feature tables, and orphan schema (no owning convention) all serve valid documents; unknown/reserved reference ids 404 via the existing `resolve_schema` guard.

## Cross-repo contract

Lands together with opensciencearchive/osa-py#10 (SDK: required `purpose`/`examples` on `convention()`, pre-flight gate mirror, field/column metadata plumbing). The deploy payload is the shared contract.

## Testing

TDD throughout. 1252 unit / 35 contract / 145 integration (real Postgres) green; ruff + ty clean. Validated end-to-end against a live server: documented deploy → 201, docs-less deploy → 422 naming the gap, then `/` → `/SKILL.md` → `/api/v1/data/{schema}.md` → `records.csv.gz`.
