### PR TITLE
refactor: untangle hook/ingestion runtime failure handling into facts → policy → action (#152)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ web/.turbo/
 .env
 !.env.example
 server/osa.yaml
+.gstack/

--- a/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
+++ b/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
@@ -90,6 +90,8 @@ def upgrade() -> None:
         sa.Column("batches_failed", sa.Integer(), server_default=sa.text("0"), nullable=False),
         sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.Column("failure_kind", sa.String(length=32), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("idx_ingest_runs_convention", "ingest_runs", ["convention_id"], unique=False)

--- a/server/osa/application/api/v1/routes/ingestions.py
+++ b/server/osa/application/api/v1/routes/ingestions.py
@@ -8,6 +8,12 @@ from osa.domain.ingest.command.start_ingest import (
     StartIngest,
     StartIngestHandler,
 )
+from osa.domain.ingest.model.ingest_run import IngestRunId
+from osa.domain.ingest.query.get_ingestion import (
+    GetIngestion,
+    GetIngestionHandler,
+    IngestRunDetail,
+)
 
 router = APIRouter(prefix="/ingestions", tags=["Ingestions"], route_class=DishkaRoute)
 
@@ -18,3 +24,11 @@ async def start_ingest(
     handler: FromDishka[StartIngestHandler],
 ) -> IngestRunCreated:
     return await handler.run(body)
+
+
+@router.get("/{ingest_run_id}", response_model=IngestRunDetail)
+async def get_ingestion(
+    ingest_run_id: str,
+    handler: FromDishka[GetIngestionHandler],
+) -> IngestRunDetail:
+    return await handler.run(GetIngestion(ingest_run_id=IngestRunId(ingest_run_id)))

--- a/server/osa/domain/ingest/handler/publish_batch.py
+++ b/server/osa/domain/ingest/handler/publish_batch.py
@@ -157,13 +157,17 @@ class PublishBatch(EventHandler[HookBatchCompleted]):
         await self.ingest_service.complete_batch(event.ingest_run_id, published_count)
 
     async def on_exhausted(self, event: HookBatchCompleted) -> None:
-        """Called when publish retries are exhausted — account for the failed batch."""
+        """Publish retries exhausted — fail the batch with a queryable reason (#152)."""
         log.error(
             "batch {batch_index} publish retries exhausted",
             batch_index=event.batch_index,
             ingest_run_id=event.ingest_run_id,
         )
-        await self.ingest_service.fail_batch(event.ingest_run_id)
+        await self.ingest_service.fail_batch(
+            event.ingest_run_id,
+            reason=f"batch {event.batch_index}: publish retries exhausted",
+            kind=None,
+        )
 
 
 async def _get_passed_records(

--- a/server/osa/domain/ingest/handler/run_hooks.py
+++ b/server/osa/domain/ingest/handler/run_hooks.py
@@ -17,7 +17,6 @@ from osa.domain.shared.failure import (
     FailurePolicy,
     PriorAttempts,
     Retry,
-    RuntimeFailure,
 )
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.model.srn import ConventionSlug
@@ -43,17 +42,6 @@ _HOOK_RUN_NS = uuid5(NAMESPACE_URL, "osa:hook_run")
 def _hook_run_id(ingest_run_id: str, batch_index: int, hook_name: HookName) -> HookRunId:
     """Deterministic hook_run id for one hook in one batch — stable across retries."""
     return HookRunId(uuid5(_HOOK_RUN_NS, f"{ingest_run_id}:{batch_index}:{hook_name.root}"))
-
-
-def _failure_from(execution: HookExecution) -> RuntimeFailure:
-    """Rehydrate the observed failure facts from a failed execution."""
-    if execution.failure is None:
-        raise ValueError(f"hook {execution.hook_name!r} did not fail")
-    return RuntimeFailure(
-        execution.failure,
-        execution.error_message or "",
-        oom_retries=execution.oom_retries,
-    )
 
 
 class RunHooks(EventHandler[IngesterBatchReady]):
@@ -168,7 +156,12 @@ class RunHooks(EventHandler[IngesterBatchReady]):
         # execution carries the observed facts; the decision matrix lives in
         # ONE place — the injected FailurePolicy (#152).
         decisions = [
-            (e, self.failure_policy.decide(_failure_from(e), PriorAttempts(e.oom_retries)))
+            (
+                e,
+                self.failure_policy.decide(
+                    e.as_failure(), PriorAttempts(memory_bumps=e.oom_retries)
+                ),
+            )
             for e in executions
             if e.failure is not None
         ]

--- a/server/osa/domain/ingest/handler/run_hooks.py
+++ b/server/osa/domain/ingest/handler/run_hooks.py
@@ -1,6 +1,7 @@
 """RunHooks — runs hook containers on an ingester batch."""
 
 from pathlib import Path
+from typing import assert_never
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from osa.domain.deposition.service.convention import ConventionService
@@ -15,8 +16,11 @@ from osa.domain.shared.event import EventHandler, EventId
 from osa.domain.shared.failure import (
     AbortRun,
     FailurePolicy,
+    GiveUp,
     PriorAttempts,
     Retry,
+    RetryWithMoreMemory,
+    most_severe,
 )
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.model.srn import ConventionSlug
@@ -152,10 +156,11 @@ class RunHooks(EventHandler[IngesterBatchReady]):
                 ingest_run_id=event.ingest_run_id,
             )
 
-        # Ask the policy what each failure means for this batch/run. The
-        # execution carries the observed facts; the decision matrix lives in
-        # ONE place — the injected FailurePolicy (#152).
-        decisions = [
+        # Ask the policy what each failure means; the execution carries the
+        # observed facts and the decision matrix lives in ONE place — the
+        # injected FailurePolicy (#152). The batch's fate is the most severe
+        # decision across its hooks: abort > retry > terminal give-up.
+        decided = [
             (
                 e,
                 self.failure_policy.decide(
@@ -166,46 +171,44 @@ class RunHooks(EventHandler[IngesterBatchReady]):
             if e.failure is not None
         ]
 
-        # AbortRun: the failure recurs identically for every batch (unpullable
-        # image, RBAC, bad config) — record the facts, hard-stop the run, and
-        # do NOT emit completion or re-drive.
-        abort = next((d for _, d in decisions if isinstance(d, AbortRun)), None)
-        if abort is not None:
-            await self._record_provenance(event, executions, work_dirs)
-            await self.ingest_service.abort_run(
-                event.ingest_run_id, reason=abort.reason, kind=abort.kind
-            )
-            return
-
-        # Retry: re-drive the whole batch. The UOW rolls back (nothing recorded
-        # this attempt), but each hook's filesystem checkpoint makes the re-run
-        # cheap — completed hooks return instantly without a container, and the
-        # deterministic id keeps the eventual insert dup-free. The worker's
-        # delivery budget bounds the retries (on_exhausted → fail_batch).
-        pending = [e for e, d in decisions if isinstance(d, Retry)]
-        if pending:
-            names = ", ".join(e.hook_name.root for e in pending)
-            raise TransientError(
-                f"batch {event.batch_index}: {len(pending)} hook(s) pending retry: {names}"
-            )
-
-        # All remaining failures are give-ups (incl. OOM with its bump budget
-        # already spent inside HookService) → record provenance from each hook's
-        # OWN execution (its real window + status; a terminal ERROR run, not a
-        # batch failure — hooks are independent) and write run.json so
-        # InsertBatchFeatures can stamp feature.run_id. record_run is idempotent.
-        await self._record_provenance(event, executions, work_dirs)
-
-        # Emit HookBatchCompleted (committed by the UOW on return). PublishBatch
-        # publishes records that passed every hook; a given-up hook just means
-        # its records aren't complete, not that the batch failed.
-        await self.outbox.append(
-            HookBatchCompleted(
-                id=EventId(uuid4()),
-                ingest_run_id=event.ingest_run_id,
-                batch_index=event.batch_index,
-            )
-        )
+        verdict = most_severe(d for _, d in decided)
+        match verdict:
+            case AbortRun(reason=reason, kind=kind):
+                # Environmental — recurs identically for every batch (unpullable
+                # image, RBAC, bad config). Record the facts, hard-stop the run,
+                # and do NOT emit completion or re-drive.
+                await self._record_provenance(event, executions, work_dirs)
+                await self.ingest_service.abort_run(event.ingest_run_id, reason=reason, kind=kind)
+            case Retry():
+                # Re-drive the whole batch. The UOW rolls back (nothing recorded
+                # this attempt), but each hook's filesystem checkpoint makes the
+                # re-run cheap and the deterministic id keeps the eventual insert
+                # dup-free. The worker's delivery budget bounds it (on_exhausted
+                # → fail_batch).
+                names = ", ".join(e.hook_name.root for e, d in decided if isinstance(d, Retry))
+                raise TransientError(f"batch {event.batch_index}: hook(s) pending retry: {names}")
+            case GiveUp() | RetryWithMoreMemory() | None:
+                # Nothing failed, or every failure is terminal at batch level (a
+                # hook's OOM bump budget is already spent inside HookService, so
+                # RetryWithMoreMemory can't reach here). Record each hook's own
+                # ERROR/PASS provenance — a given-up hook is a terminal ERROR run,
+                # not a batch failure; hooks are independent (#145) — write
+                # run.json so InsertBatchFeatures can stamp feature.run_id
+                # (record_run is idempotent), and complete the batch. PublishBatch
+                # publishes records that passed every hook.
+                await self._record_provenance(event, executions, work_dirs)
+                await self.outbox.append(
+                    HookBatchCompleted(
+                        id=EventId(uuid4()),
+                        ingest_run_id=event.ingest_run_id,
+                        batch_index=event.batch_index,
+                    )
+                )
+            case _:
+                # Every Decision variant is handled above; a new one added to the
+                # union fails `ty` here (and raises at runtime) rather than
+                # silently dropping the batch.
+                assert_never(verdict)
 
     async def _record_provenance(
         self,
@@ -246,14 +249,18 @@ class RunHooks(EventHandler[IngesterBatchReady]):
             )
 
     async def on_exhausted(self, event: IngesterBatchReady) -> None:
-        """Called when transient retries are exhausted — account for the failed batch."""
+        """Transient retries exhausted — fail the batch with a queryable reason (#152).
+
+        The individual attempts rolled back, so no single FailureKind survives to
+        this point; the reason names the batch and the kind is left unset.
+        """
         log.error(
             "batch {batch_index} retries exhausted",
             batch_index=event.batch_index,
             ingest_run_id=event.ingest_run_id,
         )
-        await self._fail_batch(event)
-
-    async def _fail_batch(self, event: IngesterBatchReady) -> None:
-        """Account for a permanently failed batch."""
-        await self.ingest_service.fail_batch(event.ingest_run_id)
+        await self.ingest_service.fail_batch(
+            event.ingest_run_id,
+            reason=f"batch {event.batch_index}: hook retries exhausted",
+            kind=None,
+        )

--- a/server/osa/domain/ingest/handler/run_hooks.py
+++ b/server/osa/domain/ingest/handler/run_hooks.py
@@ -5,17 +5,26 @@ from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.ingest.event.events import HookBatchCompleted, IngesterBatchReady
+from osa.domain.ingest.model.ingest_run import IngestStatus
 from osa.domain.ingest.model.ingester_record import IngesterRecord
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.ingest.port.storage import IngestStoragePort
 from osa.domain.ingest.service.ingest import IngestService
 from osa.domain.shared.error import NotFoundError, TransientError
 from osa.domain.shared.event import EventHandler, EventId
+from osa.domain.shared.failure import (
+    AbortRun,
+    FailurePolicy,
+    PriorAttempts,
+    Retry,
+    RuntimeFailure,
+)
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.model.srn import ConventionSlug
 from osa.domain.shared.outbox import Outbox
 from osa.domain.validation.model.hook_input import HookRecord
 from osa.domain.validation.model.hook_release import HookRelease
+from osa.domain.validation.model.hook_result import HookExecution
 from osa.domain.validation.model.hook_run import HookRun, HookRunId, HookRunStatus
 from osa.domain.validation.port.hook_runner import HookInputs
 from osa.domain.validation.service.hook import HookService
@@ -36,6 +45,17 @@ def _hook_run_id(ingest_run_id: str, batch_index: int, hook_name: HookName) -> H
     return HookRunId(uuid5(_HOOK_RUN_NS, f"{ingest_run_id}:{batch_index}:{hook_name.root}"))
 
 
+def _failure_from(execution: HookExecution) -> RuntimeFailure:
+    """Rehydrate the observed failure facts from a failed execution."""
+    if execution.failure is None:
+        raise ValueError(f"hook {execution.hook_name!r} did not fail")
+    return RuntimeFailure(
+        execution.failure,
+        execution.error_message or "",
+        oom_retries=execution.oom_retries,
+    )
+
+
 class RunHooks(EventHandler[IngesterBatchReady]):
     """Runs hook containers on an ingester batch and emits HookBatchCompleted."""
 
@@ -49,11 +69,23 @@ class RunHooks(EventHandler[IngesterBatchReady]):
     hook_registry: HookRegistryService
     outbox: Outbox
     ingest_storage: IngestStoragePort
+    failure_policy: FailurePolicy
 
     async def handle(self, event: IngesterBatchReady) -> None:
         ingest_run = await self.ingest_repo.get(event.ingest_run_id)
         if ingest_run is None:
             raise NotFoundError(f"Ingest run not found: {event.ingest_run_id}")
+
+        # An aborted/finished run schedules no more work — drop redelivered
+        # batch events instead of grinding through them one by one (#152).
+        if ingest_run.status in (IngestStatus.COMPLETED, IngestStatus.FAILED):
+            log.warn(
+                "batch {batch_index} skipped — run is {status}",
+                batch_index=event.batch_index,
+                status=ingest_run.status.value,
+                ingest_run_id=event.ingest_run_id,
+            )
+            return
 
         convention = await self.convention_service.get_convention(
             ConventionSlug.parse(ingest_run.convention_id)
@@ -132,21 +164,63 @@ class RunHooks(EventHandler[IngesterBatchReady]):
                 ingest_run_id=event.ingest_run_id,
             )
 
-        # Any TRANSIENT failure → re-drive the whole batch. The UOW rolls back
-        # (nothing recorded this attempt), but each hook's filesystem checkpoint
-        # makes the re-run cheap — completed hooks return instantly without a
-        # container, and the deterministic id keeps the eventual insert dup-free.
-        pending = [e for e in executions if not e.is_terminal]
+        # Ask the policy what each failure means for this batch/run. The
+        # execution carries the observed facts; the decision matrix lives in
+        # ONE place — the injected FailurePolicy (#152).
+        decisions = [
+            (e, self.failure_policy.decide(_failure_from(e), PriorAttempts(e.oom_retries)))
+            for e in executions
+            if e.failure is not None
+        ]
+
+        # AbortRun: the failure recurs identically for every batch (unpullable
+        # image, RBAC, bad config) — record the facts, hard-stop the run, and
+        # do NOT emit completion or re-drive.
+        abort = next((d for _, d in decisions if isinstance(d, AbortRun)), None)
+        if abort is not None:
+            await self._record_provenance(event, executions, work_dirs)
+            await self.ingest_service.abort_run(
+                event.ingest_run_id, reason=abort.reason, kind=abort.kind
+            )
+            return
+
+        # Retry: re-drive the whole batch. The UOW rolls back (nothing recorded
+        # this attempt), but each hook's filesystem checkpoint makes the re-run
+        # cheap — completed hooks return instantly without a container, and the
+        # deterministic id keeps the eventual insert dup-free. The worker's
+        # delivery budget bounds the retries (on_exhausted → fail_batch).
+        pending = [e for e, d in decisions if isinstance(d, Retry)]
         if pending:
             names = ", ".join(e.hook_name.root for e in pending)
             raise TransientError(
                 f"batch {event.batch_index}: {len(pending)} hook(s) pending retry: {names}"
             )
 
-        # All hooks terminal → record provenance from each hook's OWN execution
-        # (its real window + status; a PERMANENT/OOM failure is a terminal ERROR
-        # run, not a batch failure — hooks are independent) and write run.json so
+        # All remaining failures are give-ups (incl. OOM with its bump budget
+        # already spent inside HookService) → record provenance from each hook's
+        # OWN execution (its real window + status; a terminal ERROR run, not a
+        # batch failure — hooks are independent) and write run.json so
         # InsertBatchFeatures can stamp feature.run_id. record_run is idempotent.
+        await self._record_provenance(event, executions, work_dirs)
+
+        # Emit HookBatchCompleted (committed by the UOW on return). PublishBatch
+        # publishes records that passed every hook; a given-up hook just means
+        # its records aren't complete, not that the batch failed.
+        await self.outbox.append(
+            HookBatchCompleted(
+                id=EventId(uuid4()),
+                ingest_run_id=event.ingest_run_id,
+                batch_index=event.batch_index,
+            )
+        )
+
+    async def _record_provenance(
+        self,
+        event: IngesterBatchReady,
+        executions: list[HookExecution],
+        work_dirs: dict[HookName, Path],
+    ) -> None:
+        """Record each hook's run row + run.json from its own execution."""
         for e in executions:
             run_id = _hook_run_id(event.ingest_run_id, event.batch_index, e.hook_name)
             status = (
@@ -177,17 +251,6 @@ class RunHooks(EventHandler[IngesterBatchReady]):
             await self.ingest_storage.write_run_ref(
                 work_dirs[e.hook_name], str(run_id), str(e.release_id)
             )
-
-        # Emit HookBatchCompleted (committed by the UOW on return). PublishBatch
-        # publishes records that passed every hook; a permanently-failed hook just
-        # means its records aren't complete, not that the batch failed.
-        await self.outbox.append(
-            HookBatchCompleted(
-                id=EventId(uuid4()),
-                ingest_run_id=event.ingest_run_id,
-                batch_index=event.batch_index,
-            )
-        )
 
     async def on_exhausted(self, event: IngesterBatchReady) -> None:
         """Called when transient retries are exhausted — account for the failed batch."""

--- a/server/osa/domain/ingest/handler/run_ingester.py
+++ b/server/osa/domain/ingest/handler/run_ingester.py
@@ -1,6 +1,7 @@
 """RunIngester — runs ingester container on NextBatchRequested."""
 
 from datetime import UTC, datetime, timedelta
+from typing import assert_never
 from uuid import uuid4
 
 from osa.domain.deposition.service.convention import ConventionService
@@ -17,6 +18,7 @@ from osa.domain.shared.failure import (
     GiveUp,
     PriorAttempts,
     Retry,
+    RetryWithMoreMemory,
     RuntimeFailure,
 )
 from osa.domain.shared.model.srn import ConventionSlug
@@ -161,10 +163,24 @@ class RunIngester(EventHandler[NextBatchRequested]):
                     await self.ingest_service.fail_ingestion(
                         event.ingest_run_id, reason=reason, kind=kind
                     )
-                case _:  # RetryWithMoreMemory — not executable for ingester Jobs
+                case RetryWithMoreMemory():
+                    # Ingester Jobs have no memory-bump lever (unlike hooks, which
+                    # retry inside HookService), so an OOM can't be remediated —
+                    # degrade to a give-up carrying the original OOM facts.
+                    log.error(
+                        "[{short_id}] ingester OOM, no memory-bump lever: {error}",
+                        short_id=event.ingest_run_id[:8],
+                        error=failure.detail,
+                        container_logs=failure.container_logs or "",
+                        ingest_run_id=event.ingest_run_id,
+                    )
                     await self.ingest_service.fail_ingestion(
                         event.ingest_run_id, reason=failure.detail, kind=failure.kind
                     )
+                case _:
+                    # Every Decision variant is handled above; a new one added to
+                    # the union will fail `ty` here (and raise at runtime).
+                    assert_never(decision)
             return
 
         await self.ingest_storage.write_records(event.ingest_run_id, batch_index, output.records)

--- a/server/osa/domain/ingest/handler/run_ingester.py
+++ b/server/osa/domain/ingest/handler/run_ingester.py
@@ -9,8 +9,16 @@ from osa.domain.ingest.model.ingest_run import IngestStatus
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.ingest.port.storage import IngestStoragePort
 from osa.domain.ingest.service.ingest import IngestService
-from osa.domain.shared.error import NotFoundError, PermanentError
+from osa.domain.shared.error import NotFoundError, TransientError
 from osa.domain.shared.event import EventHandler, EventId
+from osa.domain.shared.failure import (
+    AbortRun,
+    FailurePolicy,
+    GiveUp,
+    PriorAttempts,
+    Retry,
+    RuntimeFailure,
+)
 from osa.domain.shared.model.srn import ConventionSlug
 from osa.domain.shared.outbox import Outbox
 from osa.domain.shared.port.ingester_runner import IngesterInputs, IngesterRunner
@@ -33,11 +41,22 @@ class RunIngester(EventHandler[NextBatchRequested]):
     ingester_runner: IngesterRunner
     outbox: Outbox
     ingest_storage: IngestStoragePort
+    failure_policy: FailurePolicy
 
     async def handle(self, event: NextBatchRequested) -> None:
         ingest_run = await self.ingest_repo.get(event.ingest_run_id)
         if ingest_run is None:
             raise NotFoundError(f"Ingest run not found: {event.ingest_run_id}")
+
+        # An aborted/finished run pulls no more batches — drop redelivered
+        # events instead of sourcing work nobody will process (#152).
+        if ingest_run.status in (IngestStatus.COMPLETED, IngestStatus.FAILED):
+            log.warn(
+                "next-batch request skipped — run is {status}",
+                status=ingest_run.status.value,
+                ingest_run_id=event.ingest_run_id,
+            )
+            return
 
         # Backpressure: don't ingest if the cluster can't schedule more Jobs
         if not await self.ingester_runner.has_capacity():
@@ -108,15 +127,44 @@ class RunIngester(EventHandler[NextBatchRequested]):
                 files_dir=files_dir,
                 work_dir=work_dir,
             )
-        except PermanentError as e:
-            log.error(
-                "[{short_id}] ingester permanently failed: {error}",
-                short_id=event.ingest_run_id[:8],
-                error=str(e),
-                container_logs=e.container_logs or "",
-                ingest_run_id=event.ingest_run_id,
-            )
-            await self._fail_ingestion(event)
+        except RuntimeFailure as failure:
+            # The runner reports facts; the policy decides; we execute the verb.
+            # Ingester Jobs have no memory-bump lever, so PriorAttempts carries
+            # no bumps and an OOM decision degrades to a give-up below.
+            decision = self.failure_policy.decide(failure, PriorAttempts(memory_bumps=0))
+            match decision:
+                case AbortRun(reason=reason, kind=kind):
+                    log.error(
+                        "[{short_id}] ingester failed for the whole run ({kind}): {error}",
+                        short_id=event.ingest_run_id[:8],
+                        kind=kind.value,
+                        error=reason,
+                        container_logs=failure.container_logs or "",
+                        ingest_run_id=event.ingest_run_id,
+                    )
+                    await self.ingest_service.abort_run(
+                        event.ingest_run_id, reason=reason, kind=kind
+                    )
+                case Retry():
+                    # Re-raise for the worker's budgeted redelivery with backoff;
+                    # exhaustion lands in on_exhausted → fail_ingestion.
+                    raise TransientError(failure.detail) from failure
+                case GiveUp(reason=reason, kind=kind):
+                    log.error(
+                        "[{short_id}] ingester gave up ({kind}): {error}",
+                        short_id=event.ingest_run_id[:8],
+                        kind=kind.value,
+                        error=reason,
+                        container_logs=failure.container_logs or "",
+                        ingest_run_id=event.ingest_run_id,
+                    )
+                    await self.ingest_service.fail_ingestion(
+                        event.ingest_run_id, reason=reason, kind=kind
+                    )
+                case _:  # RetryWithMoreMemory — not executable for ingester Jobs
+                    await self.ingest_service.fail_ingestion(
+                        event.ingest_run_id, reason=failure.detail, kind=failure.kind
+                    )
             return
 
         await self.ingest_storage.write_records(event.ingest_run_id, batch_index, output.records)
@@ -171,8 +219,6 @@ class RunIngester(EventHandler[NextBatchRequested]):
             "ingester retries exhausted",
             ingest_run_id=event.ingest_run_id,
         )
-        await self._fail_ingestion(event)
-
-    async def _fail_ingestion(self, event: NextBatchRequested) -> None:
-        """Account for a permanently failed ingester pull."""
-        await self.ingest_service.fail_ingestion(event.ingest_run_id)
+        await self.ingest_service.fail_ingestion(
+            event.ingest_run_id, reason="ingester retries exhausted", kind=None
+        )

--- a/server/osa/domain/ingest/model/ingest_run.py
+++ b/server/osa/domain/ingest/model/ingest_run.py
@@ -1,5 +1,6 @@
 """IngestRun aggregate — lean summary tracking a bulk ingestion execution."""
 
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import NewType
@@ -100,3 +101,25 @@ class IngestRun(Aggregate):
             self.completed_at = completed_at
             return True
         return False
+
+
+# ── Guarded-mutation outcome ─────────────────────────────────────────────────
+# Counter/state mutations only apply while a run is non-terminal (#152). The
+# repo reports which happened via this sum type instead of an ambiguous None: a
+# genuinely-missing run raises NotFoundError (exceptional); an already-terminal
+# run is an expected concurrent no-op (RunClosed).
+
+
+@dataclass(frozen=True)
+class Applied:
+    """The guarded mutation landed; carries the DB-authoritative run."""
+
+    run: IngestRun
+
+
+@dataclass(frozen=True)
+class RunClosed:
+    """The run was already terminal — the mutation was a deliberate no-op."""
+
+
+RunUpdate = Applied | RunClosed

--- a/server/osa/domain/ingest/model/ingest_run.py
+++ b/server/osa/domain/ingest/model/ingest_run.py
@@ -5,6 +5,7 @@ from enum import StrEnum
 from typing import NewType
 
 from osa.domain.shared.error import InvalidStateError
+from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.model.aggregate import Aggregate
 
 IngestRunId = NewType("IngestRunId", str)
@@ -44,6 +45,10 @@ class IngestRun(Aggregate):
     limit: int | None = None  # Max total records (None = unlimited)
     started_at: datetime
     completed_at: datetime | None = None
+    # Why the run failed (or why ingestion stopped early), queryable via
+    # GET /ingestions/{id} (#152). None for healthy runs.
+    failure_reason: str | None = None
+    failure_kind: FailureKind | None = None
 
     def transition_to(self, new_status: IngestStatus) -> None:
         """Transition to a new status, enforcing valid transitions."""
@@ -54,9 +59,13 @@ class IngestRun(Aggregate):
     def mark_running(self) -> None:
         self.transition_to(IngestStatus.RUNNING)
 
-    def mark_failed(self, completed_at: datetime) -> None:
+    def mark_failed(self, completed_at: datetime, *, reason: str, kind: FailureKind) -> None:
+        """Fail the whole run with a queryable explanation; stops batch scheduling."""
         self.transition_to(IngestStatus.FAILED)
         self.completed_at = completed_at
+        self.failure_reason = reason
+        self.failure_kind = kind
+        self.ingestion_finished = True
 
     def mark_ingestion_finished(self) -> None:
         self.ingestion_finished = True

--- a/server/osa/domain/ingest/port/repository.py
+++ b/server/osa/domain/ingest/port/repository.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from datetime import datetime
 from typing import Protocol
 
-from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId
+from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, RunUpdate
 from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.port import Port
 
@@ -35,27 +35,29 @@ class IngestRunRepository(Port, Protocol):
     @abstractmethod
     async def increment_batches_ingested(
         self, id: IngestRunId, *, set_ingestion_finished: bool = False
-    ) -> IngestRun:
-        """Atomically increment batches_ingested and optionally set ingestion_finished.
+    ) -> RunUpdate:
+        """Atomically increment batches_ingested while the run is non-terminal.
 
-        Returns the updated IngestRun with DB-authoritative counter values.
+        Returns ``Applied`` (with the updated run), or ``RunClosed`` when the run
+        is already terminal; raises ``NotFoundError`` if the run is missing.
         """
         ...
 
     @abstractmethod
-    async def increment_failed(self, id: IngestRunId) -> IngestRun:
-        """Atomically increment batches_failed.
+    async def increment_failed(self, id: IngestRunId) -> RunUpdate:
+        """Atomically increment batches_failed while the run is non-terminal.
 
-        Returns the updated IngestRun for completion condition checking.
+        ``Applied`` (with the run) for completion checking, ``RunClosed`` when
+        already terminal; raises ``NotFoundError`` if missing.
         """
         ...
 
     @abstractmethod
-    async def increment_completed(self, id: IngestRunId, published_count: int) -> IngestRun:
-        """Atomically increment batches_completed and published_count.
+    async def increment_completed(self, id: IngestRunId, published_count: int) -> RunUpdate:
+        """Atomically increment batches_completed and published_count, non-terminal only.
 
-        Returns the updated IngestRun with DB-authoritative counter values
-        for completion condition checking.
+        ``Applied`` (with the run) for completion checking, ``RunClosed`` when
+        already terminal; raises ``NotFoundError`` if missing.
         """
         ...
 
@@ -67,13 +69,13 @@ class IngestRunRepository(Port, Protocol):
         reason: str,
         kind: FailureKind,
         completed_at: datetime,
-    ) -> IngestRun | None:
+    ) -> RunUpdate:
         """Atomically fail a run with its explanation, if it is not already terminal.
 
         Sets status=FAILED, failure_reason/failure_kind, ingestion_finished and
         completed_at in one guarded UPDATE so concurrent batch workers can race
-        to abort safely. Returns the updated run, or None if the run was
-        already COMPLETED/FAILED (idempotent no-op).
+        to abort safely. Returns ``Applied`` (with the updated run), or
+        ``RunClosed`` if the run was already COMPLETED/FAILED (idempotent no-op).
         """
         ...
 

--- a/server/osa/domain/ingest/port/repository.py
+++ b/server/osa/domain/ingest/port/repository.py
@@ -1,9 +1,11 @@
 """IngestRunRepository port — persistence interface for ingest runs."""
 
 from abc import abstractmethod
+from datetime import datetime
 from typing import Protocol
 
 from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId
+from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.port import Port
 
 
@@ -54,5 +56,34 @@ class IngestRunRepository(Port, Protocol):
 
         Returns the updated IngestRun with DB-authoritative counter values
         for completion condition checking.
+        """
+        ...
+
+    @abstractmethod
+    async def abort(
+        self,
+        id: IngestRunId,
+        *,
+        reason: str,
+        kind: FailureKind,
+        completed_at: datetime,
+    ) -> IngestRun | None:
+        """Atomically fail a run with its explanation, if it is not already terminal.
+
+        Sets status=FAILED, failure_reason/failure_kind, ingestion_finished and
+        completed_at in one guarded UPDATE so concurrent batch workers can race
+        to abort safely. Returns the updated run, or None if the run was
+        already COMPLETED/FAILED (idempotent no-op).
+        """
+        ...
+
+    @abstractmethod
+    async def record_failure(
+        self, id: IngestRunId, *, reason: str, kind: FailureKind | None
+    ) -> None:
+        """Record why ingestion stopped early, without changing run status.
+
+        Used when the ingester gives up but already-sourced batches may still
+        complete the run normally.
         """
         ...

--- a/server/osa/domain/ingest/query/get_ingestion.py
+++ b/server/osa/domain/ingest/query/get_ingestion.py
@@ -1,0 +1,67 @@
+"""GetIngestion query — inspect an ingest run, including why it failed (#152)."""
+
+from datetime import datetime
+
+from osa.domain.auth.model.principal import Principal
+from osa.domain.auth.model.role import Role
+from osa.domain.ingest.model.ingest_run import IngestRunId, IngestStatus
+from osa.domain.ingest.service.ingest import IngestService
+from osa.domain.shared.authorization.gate import at_least
+from osa.domain.shared.failure import FailureKind
+from osa.domain.shared.query import Query, QueryHandler, Result
+
+
+class GetIngestion(Query):
+    ingest_run_id: IngestRunId
+
+
+class IngestRunDetail(Result):
+    """Read shape of an ingest run.
+
+    ``failure_reason``/``failure_kind`` carry the queryable explanation for a
+    failed run (or an ingestion that stopped early) — the operator-facing
+    surface for what previously survived only in delivery errors and app logs.
+    """
+
+    id: IngestRunId
+    convention_id: str
+    status: IngestStatus
+    ingestion_finished: bool
+    batches_ingested: int
+    batches_completed: int
+    batches_failed: int
+    published_count: int
+    batch_size: int
+    limit: int | None
+    started_at: datetime
+    completed_at: datetime | None
+    failure_reason: str | None
+    failure_kind: FailureKind | None
+
+
+class GetIngestionHandler(QueryHandler[GetIngestion, IngestRunDetail]):
+    """Thin query handler — delegates to IngestService."""
+
+    __auth__ = at_least(Role.ADMIN)
+
+    principal: Principal
+    service: IngestService
+
+    async def run(self, cmd: GetIngestion) -> IngestRunDetail:
+        ingest_run = await self.service.get_ingestion(cmd.ingest_run_id)
+        return IngestRunDetail(
+            id=ingest_run.id,
+            convention_id=ingest_run.convention_id,
+            status=ingest_run.status,
+            ingestion_finished=ingest_run.ingestion_finished,
+            batches_ingested=ingest_run.batches_ingested,
+            batches_completed=ingest_run.batches_completed,
+            batches_failed=ingest_run.batches_failed,
+            published_count=ingest_run.published_count,
+            batch_size=ingest_run.batch_size,
+            limit=ingest_run.limit,
+            started_at=ingest_run.started_at,
+            completed_at=ingest_run.completed_at,
+            failure_reason=ingest_run.failure_reason,
+            failure_kind=ingest_run.failure_kind,
+        )

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -97,6 +97,13 @@ class IngestService(Service):
         )
         return ingest_run
 
+    async def get_ingestion(self, ingest_run_id: IngestRunId) -> IngestRun:
+        """Fetch an ingest run by id, raising NotFoundError if absent."""
+        ingest_run = await self.ingest_repo.get(ingest_run_id)
+        if ingest_run is None:
+            raise NotFoundError(f"Ingest run not found: {ingest_run_id}")
+        return ingest_run
+
     async def complete_batch(self, ingest_run_id: IngestRunId, published_count: int) -> None:
         """Account for a successfully processed batch.
 

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -115,14 +115,20 @@ class IngestService(Service):
         )
         await self._check_completion(ingest_run)
 
-    async def fail_batch(self, ingest_run_id: IngestRunId) -> None:
-        """Account for a batch that permanently failed hook processing.
+    async def fail_batch(
+        self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind | None = None
+    ) -> None:
+        """Account for a batch that permanently failed hook/publish processing (#152).
 
-        Increments batches_failed and completes the run if all batches
-        are now accounted for (completed + failed >= ingested).
+        Increments batches_failed, completes the run if all batches are now
+        accounted for (completed + failed >= ingested), and records why so an
+        operator sees the explanation on the run. ``record_failure`` runs LAST:
+        a completing run's aggregate save (in ``_check_completion``) would
+        otherwise clobber the reason with the aggregate's stale null.
         """
         ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
         await self._check_completion(ingest_run)
+        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
     async def fail_ingestion(
         self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind | None
@@ -130,18 +136,19 @@ class IngestService(Service):
         """Account for a failed ingester pull, recording why (#152).
 
         The batch was never sourced, so we mark ingestion as finished
-        (no more batches coming) and increment batches_failed. The
-        completion condition can then fire based on whatever batches
-        were already sourced. The reason/kind land on the run so an
-        operator sees the explanation without log archaeology.
+        (no more batches coming) and increment batches_failed. The completion
+        condition can then fire based on whatever batches were already sourced.
+        The reason/kind land on the run so an operator sees the explanation
+        without log archaeology. ``record_failure`` runs LAST for the same
+        reason as ``fail_batch`` — so a completing run's save can't clobber it.
         """
         await self.ingest_repo.increment_batches_ingested(
             ingest_run_id,
             set_ingestion_finished=True,
         )
         ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
-        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
         await self._check_completion(ingest_run)
+        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
     async def abort_run(
         self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -5,7 +5,13 @@ from uuid import uuid4
 
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.ingest.event.events import IngestCompleted, IngestRunStarted, NextBatchRequested
-from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
+from osa.domain.ingest.model.ingest_run import (
+    Applied,
+    IngestRun,
+    IngestRunId,
+    IngestStatus,
+    RunClosed,
+)
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.shared.error import ConflictError, NotFoundError
 from osa.domain.shared.event import EventId
@@ -110,10 +116,20 @@ class IngestService(Service):
         Increments batches_completed and published_count atomically,
         then checks the completion condition.
         """
-        ingest_run = await self.ingest_repo.increment_completed(
+        match await self.ingest_repo.increment_completed(
             ingest_run_id, published_count=published_count
-        )
-        await self._check_completion(ingest_run)
+        ):
+            case RunClosed():
+                # A late/stale batch reached a closed run — expected under
+                # concurrency, but logged so it's never silent when we're
+                # chasing "why is a counter off / a record missing".
+                log.warn(
+                    "complete_batch no-op — run already terminal",
+                    ingest_run_id=ingest_run_id,
+                    published_count=published_count,
+                )
+            case Applied(run):
+                await self._check_completion(run)
 
     async def fail_batch(
         self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind | None = None
@@ -126,9 +142,16 @@ class IngestService(Service):
         a completing run's aggregate save (in ``_check_completion``) would
         otherwise clobber the reason with the aggregate's stale null.
         """
-        ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
-        await self._check_completion(ingest_run)
-        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
+        match await self.ingest_repo.increment_failed(ingest_run_id):
+            case RunClosed():
+                log.warn(
+                    "fail_batch no-op — run already terminal",
+                    ingest_run_id=ingest_run_id,
+                    reason=reason,
+                )
+            case Applied(run):
+                await self._check_completion(run)
+                await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
     async def fail_ingestion(
         self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind | None
@@ -142,13 +165,29 @@ class IngestService(Service):
         without log archaeology. ``record_failure`` runs LAST for the same
         reason as ``fail_batch`` — so a completing run's save can't clobber it.
         """
-        await self.ingest_repo.increment_batches_ingested(
+        match await self.ingest_repo.increment_batches_ingested(
             ingest_run_id,
             set_ingestion_finished=True,
-        )
-        ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
-        await self._check_completion(ingest_run)
-        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
+        ):
+            case RunClosed():
+                log.warn(
+                    "fail_ingestion no-op — run already terminal",
+                    ingest_run_id=ingest_run_id,
+                    reason=reason,
+                )
+                return
+            case Applied():
+                pass
+        match await self.ingest_repo.increment_failed(ingest_run_id):
+            case RunClosed():
+                log.warn(
+                    "fail_ingestion no-op — run terminalized concurrently",
+                    ingest_run_id=ingest_run_id,
+                    reason=reason,
+                )
+            case Applied(run):
+                await self._check_completion(run)
+                await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
     async def abort_run(
         self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind
@@ -161,25 +200,25 @@ class IngestService(Service):
         that is already terminal is left untouched (concurrent batch workers
         may race to abort).
         """
-        ingest_run = await self.ingest_repo.abort(
+        match await self.ingest_repo.abort(
             ingest_run_id,
             reason=reason,
             kind=kind,
             completed_at=datetime.now(UTC),
-        )
-        if ingest_run is None:
-            log.info(
-                "abort no-op — run already terminal",
-                ingest_run_id=ingest_run_id,
-            )
-            return
-        log.error(
-            "[{short_id}] run ABORTED ({kind}): {reason}",
-            short_id=str(ingest_run_id)[:8],
-            kind=kind.value,
-            reason=reason,
-            ingest_run_id=ingest_run_id,
-        )
+        ):
+            case RunClosed():
+                log.warn(
+                    "abort no-op — run already terminal",
+                    ingest_run_id=ingest_run_id,
+                )
+            case Applied():
+                log.error(
+                    "[{short_id}] run ABORTED ({kind}): {reason}",
+                    short_id=str(ingest_run_id)[:8],
+                    kind=kind.value,
+                    reason=reason,
+                    ingest_run_id=ingest_run_id,
+                )
 
     async def _check_completion(self, ingest_run: IngestRun) -> None:
         """Transition to COMPLETED and emit IngestCompleted if all batches are accounted for."""

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -9,6 +9,7 @@ from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestSta
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.shared.error import ConflictError, NotFoundError
 from osa.domain.shared.event import EventId
+from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.model.srn import ConventionSlug, Domain
 from osa.domain.shared.outbox import Outbox
 from osa.domain.shared.service import Service
@@ -116,20 +117,55 @@ class IngestService(Service):
         ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
         await self._check_completion(ingest_run)
 
-    async def fail_ingestion(self, ingest_run_id: IngestRunId) -> None:
-        """Account for a failed ingester pull.
+    async def fail_ingestion(
+        self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind | None
+    ) -> None:
+        """Account for a failed ingester pull, recording why (#152).
 
         The batch was never sourced, so we mark ingestion as finished
         (no more batches coming) and increment batches_failed. The
         completion condition can then fire based on whatever batches
-        were already sourced.
+        were already sourced. The reason/kind land on the run so an
+        operator sees the explanation without log archaeology.
         """
         await self.ingest_repo.increment_batches_ingested(
             ingest_run_id,
             set_ingestion_finished=True,
         )
         ingest_run = await self.ingest_repo.increment_failed(ingest_run_id)
+        await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
         await self._check_completion(ingest_run)
+
+    async def abort_run(
+        self, ingest_run_id: IngestRunId, *, reason: str, kind: FailureKind
+    ) -> None:
+        """Hard-stop a run on a deterministic environmental failure (#152).
+
+        The failure would recur identically for every batch (unpullable image,
+        RBAC, bad config), so the run is failed immediately with a queryable
+        explanation and no further batches are scheduled. Idempotent: a run
+        that is already terminal is left untouched (concurrent batch workers
+        may race to abort).
+        """
+        ingest_run = await self.ingest_repo.abort(
+            ingest_run_id,
+            reason=reason,
+            kind=kind,
+            completed_at=datetime.now(UTC),
+        )
+        if ingest_run is None:
+            log.info(
+                "abort no-op — run already terminal",
+                ingest_run_id=ingest_run_id,
+            )
+            return
+        log.error(
+            "[{short_id}] run ABORTED ({kind}): {reason}",
+            short_id=str(ingest_run_id)[:8],
+            kind=kind.value,
+            reason=reason,
+            ingest_run_id=ingest_run_id,
+        )
 
     async def _check_completion(self, ingest_run: IngestRun) -> None:
         """Transition to COMPLETED and emit IngestCompleted if all batches are accounted for."""

--- a/server/osa/domain/shared/error.py
+++ b/server/osa/domain/shared/error.py
@@ -84,16 +84,6 @@ class AuthorizationError(DomainError):
 class InfrastructureError(OSAError):
     """Base class for infrastructure/system errors."""
 
-    def __init__(
-        self, message: str, code: str | None = None, *, container_logs: str | None = None
-    ) -> None:
-        super().__init__(message, code)
-        # Captured stdout/stderr of the failed container, when available. A typed
-        # field (not a loose attribute) so callers read it without getattr. Some
-        # runners fetch logs only in their catch block and assign it post-raise —
-        # that's still a typed assignment.
-        self.container_logs = container_logs
-
 
 class StorageUnavailableError(InfrastructureError):
     """Storage backend (database, object store) is unavailable."""
@@ -108,28 +98,18 @@ class ConfigurationError(InfrastructureError):
 
 
 class TransientError(InfrastructureError):
-    """Temporary failure — worker retries with backoff."""
+    """Worker delivery-control verb: retry this delivery with backoff.
+
+    Raised by event handlers when a unit of work should be re-driven; the
+    worker enforces the retry budget (``delivery.retry_count``) and calls
+    ``on_exhausted`` when it is spent. Container runners do NOT raise this —
+    they report :class:`osa.domain.shared.failure.RuntimeFailure` facts and the
+    FailurePolicy decides (#152).
+    """
 
 
 class PermanentError(InfrastructureError):
-    """Unrecoverable failure — worker gives up."""
-
-
-class OOMError(PermanentError):
-    """Container killed by out-of-memory. HookService intercepts for memory retry."""
-
-    def __init__(
-        self,
-        message: str,
-        oom_retries: int | None = None,
-        *,
-        container_logs: str | None = None,
-    ) -> None:
-        super().__init__(message, container_logs=container_logs)
-        # Number of doubled-memory retries performed before exhaustion (set by
-        # HookService.run_hook when it gives up), so provenance records the real
-        # count even though the failure surfaces as an exception (#145).
-        self.oom_retries = oom_retries
+    """Worker delivery-control verb: fail this delivery now, no retry."""
 
 
 # =============================================================================

--- a/server/osa/domain/shared/failure.py
+++ b/server/osa/domain/shared/failure.py
@@ -20,8 +20,10 @@ These exceptions drive worker retry policy, not HTTP responses, so
 ``InfrastructureError`` tree.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import assert_never
 
 from osa.domain.shared.error import OSAError
 
@@ -106,6 +108,33 @@ class AbortRun:
 
 
 Decision = Retry | RetryWithMoreMemory | GiveUp | AbortRun
+
+
+def _precedence(decision: Decision) -> int:
+    """Rank a decision by blast radius, so several can be reduced to the one that wins."""
+    match decision:
+        case AbortRun():
+            return 3  # kills the whole run
+        case Retry():
+            return 2  # re-drive the batch
+        case RetryWithMoreMemory():
+            return 1  # remediation; terminal at batch level (bump lever is HookService's)
+        case GiveUp():
+            return 0  # record this unit and move on
+    assert_never(decision)
+
+
+def most_severe(decisions: Iterable[Decision]) -> Decision | None:
+    """The decision that dominates when one batch yields several.
+
+    When a batch runs N hooks, each failed hook produces a decision; the batch's
+    fate is the most severe among them (:func:`_precedence`): an ``AbortRun``
+    dominates a ``Retry`` dominates the terminal per-hook verbs. Lets a handler
+    pick one action without a chain of ``isinstance`` checks. Returns ``None``
+    for a batch that produced no decision (nothing failed); ties keep the
+    first-seen decision.
+    """
+    return max(decisions, key=_precedence, default=None)
 
 
 @dataclass(frozen=True)

--- a/server/osa/domain/shared/failure.py
+++ b/server/osa/domain/shared/failure.py
@@ -1,0 +1,138 @@
+"""Runtime failure taxonomy: facts → policy → action (#152).
+
+When a hook or ingester container fails, three concerns must stay apart:
+
+- **Facts** (:class:`RuntimeFailure`): what the runner observed — the cause
+  (:class:`FailureKind`) plus diagnostics. No disposition baked in.
+- **Policy** (:class:`FailurePolicy`): one pure function mapping
+  ``(failure, prior attempts) → action``. The only place the rules live.
+- **Actions** (:data:`Decision`): the verb an executor carries out. Blast
+  radius is *which* verb the policy picks (:class:`GiveUp` dooms one batch,
+  :class:`AbortRun` dooms the whole run) — not a property failures carry.
+
+Budget split: the outbox/worker keeps the generic transient redelivery budget
+(it owns ``delivery.retry_count``), so :class:`Retry` is unconditional here and
+exhaustion is enforced by the worker via ``on_exhausted``. The policy owns the
+one budget the outbox cannot see: OOM memory bumps (:class:`PriorAttempts`).
+
+These exceptions drive worker retry policy, not HTTP responses, so
+:class:`RuntimeFailure` deliberately sits outside the 503-mapped
+``InfrastructureError`` tree.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from osa.domain.shared.error import OSAError
+
+
+class FailureKind(StrEnum):
+    """The observed cause of a hook/ingester runtime failure."""
+
+    IMAGE_PULL = "image_pull"  # ErrImagePull / ImagePullBackOff
+    RBAC = "rbac"  # K8s API 403 — ServiceAccount misconfiguration
+    CONFIG = "config"  # environment misconfiguration (missing namespace, ...)
+    OOM = "oom"  # container killed by the OOM killer
+    TIMEOUT = "timeout"  # scheduling/execution/watch deadline exceeded
+    UPSTREAM = "upstream"  # ingester non-zero exit — usually an upstream API failure
+    HOOK_EXIT = "hook_exit"  # hook non-zero exit — deterministic code failure
+    RUNTIME = "runtime"  # container runtime hiccup (docker error, eviction, K8s 5xx)
+    UNKNOWN = "unknown"
+
+
+class RuntimeFailure(OSAError):
+    """A runtime failure observation raised by a container runner.
+
+    Facts only — the cause and diagnostics of what happened. Disposition
+    (retry / give up / abort) is decided by :class:`FailurePolicy`, never here.
+    """
+
+    def __init__(
+        self,
+        kind: FailureKind,
+        detail: str,
+        *,
+        exit_code: int | None = None,
+        container_logs: str | None = None,
+        oom_retries: int = 0,
+    ) -> None:
+        super().__init__(detail, code=kind.value)
+        self.kind = kind
+        self.detail = detail
+        self.exit_code = exit_code
+        # Captured stdout/stderr of the failed container, when available. Some
+        # runners fetch logs only in their catch block and assign post-raise.
+        self.container_logs = container_logs
+        # Memory bumps performed before HookService gave up on an OOM (#145).
+        # Runners always raise with 0; HookService re-raises with the real count.
+        self.oom_retries = oom_retries
+
+
+@dataclass(frozen=True)
+class PriorAttempts:
+    """Remediation state the policy consults — a view over existing data.
+
+    Only the budget the outbox doesn't track: transient redelivery counts stay
+    on ``deliveries.retry_count`` and are enforced by the worker.
+    """
+
+    memory_bumps: int
+
+
+@dataclass(frozen=True)
+class Retry:
+    """Re-drive the failed unit of work; the worker's delivery budget bounds it."""
+
+
+@dataclass(frozen=True)
+class RetryWithMoreMemory:
+    """Re-run with a doubled memory limit — the only adjust-and-rerun today."""
+
+
+@dataclass(frozen=True)
+class GiveUp:
+    """Stop trying this unit of work (batch / pull); the run continues."""
+
+    reason: str
+    kind: FailureKind
+
+
+@dataclass(frozen=True)
+class AbortRun:
+    """The failure recurs identically for every batch — stop the whole run."""
+
+    reason: str
+    kind: FailureKind
+
+
+Decision = Retry | RetryWithMoreMemory | GiveUp | AbortRun
+
+
+@dataclass(frozen=True)
+class FailurePolicy:
+    """The whole runtime-failure decision matrix, as one pure function."""
+
+    max_memory_bumps: int = 3
+
+    def decide(self, failure: RuntimeFailure, attempts: PriorAttempts) -> Decision:
+        """Map an observed failure + prior remediation attempts to an action."""
+        match failure.kind:
+            case FailureKind.IMAGE_PULL | FailureKind.RBAC | FailureKind.CONFIG:
+                # Environmental — will recur identically; nothing to retry.
+                return AbortRun(reason=failure.detail, kind=failure.kind)
+            case FailureKind.OOM:
+                if attempts.memory_bumps < self.max_memory_bumps:
+                    return RetryWithMoreMemory()
+                return GiveUp(
+                    reason=f"out of memory headroom after {attempts.memory_bumps} bumps",
+                    kind=failure.kind,
+                )
+            case FailureKind.TIMEOUT | FailureKind.UPSTREAM | FailureKind.RUNTIME:
+                return Retry()
+            case FailureKind.HOOK_EXIT:
+                # Deterministic code failure — a blind rerun would fail identically.
+                return GiveUp(
+                    reason=f"hook exited with code {failure.exit_code}", kind=failure.kind
+                )
+            case _:
+                return GiveUp(reason=failure.detail, kind=failure.kind)

--- a/server/osa/domain/validation/model/hook_result.py
+++ b/server/osa/domain/validation/model/hook_result.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 
 from pydantic import Field
 
-from osa.domain.shared.error import InfrastructureError, OOMError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.model.value import ValueObject
 from osa.domain.validation.model.hook_release import HookRelease, HookReleaseId
@@ -41,23 +41,16 @@ class HookResult(ValueObject):
     ``hook_runs`` provenance record."""
 
 
-class FailureKind(StrEnum):
-    """Why a hook's batch run failed — drives the batch's retry/complete fate."""
-
-    TRANSIENT = "transient"  # re-drivable (worker retries the batch)
-    PERMANENT = "permanent"  # give up; record as a terminal ERROR
-    OOM_EXHAUSTED = "oom_exhausted"  # give up after memory retries; partial output is valid
-
-
 class HookExecution(ValueObject):
     """One hook's **total** outcome from a batch run, with its own wall-clock window (#145).
 
     Every hook produces exactly one of these — passed, rejected, or errored
-    (with a :class:`FailureKind`) — instead of a failure unwinding the batch loop
-    and discarding sibling hooks' results. ``started_at``/``finished_at`` bracket
-    *this* hook's run (hooks run sequentially, so a shared batch window would
-    misdate every hook after the first). A ``TRANSIENT`` failure is the only
-    non-terminal outcome: it re-drives the batch.
+    (with the observed :class:`FailureKind`) — instead of a failure unwinding
+    the batch loop and discarding sibling hooks' results. The kind is a fact
+    (what happened); what to do about it is the FailurePolicy's call in the
+    handler. ``started_at``/``finished_at`` bracket *this* hook's run (hooks run
+    sequentially, so a shared batch window would misdate every hook after the
+    first).
     """
 
     hook_name: HookName
@@ -74,11 +67,6 @@ class HookExecution(ValueObject):
     (#145/#147). The ingestion handler persists this to a tenant-scoped artifact
     and records the locator as ``HookRun.log_ref``. ``None`` for passed hooks or
     when log capture itself failed."""
-
-    @property
-    def is_terminal(self) -> bool:
-        """Terminal = anything except a transient (re-drivable) failure."""
-        return self.failure is not FailureKind.TRANSIENT
 
     @classmethod
     def completed(
@@ -106,19 +94,11 @@ class HookExecution(ValueObject):
         cls,
         hook: HookIdentity,
         release: HookRelease,
-        exc: InfrastructureError,
+        failure: RuntimeFailure,
         started_at: datetime,
         finished_at: datetime,
     ) -> HookExecution:
-        # The batch wrapper only catches InfrastructureError subclasses, so
-        # ``container_logs`` is a typed field here — no getattr needed.
-        # OOMError is a subclass of PermanentError, so check it first.
-        if isinstance(exc, OOMError):
-            kind, oom_retries = FailureKind.OOM_EXHAUSTED, exc.oom_retries or 0
-        elif isinstance(exc, TransientError):
-            kind, oom_retries = FailureKind.TRANSIENT, 0
-        else:
-            kind, oom_retries = FailureKind.PERMANENT, 0
+        # The failure already carries the observed facts — no isinstance tree.
         return cls(
             hook_name=hook.name,
             release_id=release.id,
@@ -126,8 +106,8 @@ class HookExecution(ValueObject):
             started_at=started_at,
             finished_at=finished_at,
             duration_s=(finished_at - started_at).total_seconds(),
-            oom_retries=oom_retries,
-            failure=kind,
-            error_message=str(exc),
-            log_text=exc.container_logs,
+            oom_retries=failure.oom_retries,
+            failure=failure.kind,
+            error_message=str(failure),
+            log_text=failure.container_logs,
         )

--- a/server/osa/domain/validation/model/hook_result.py
+++ b/server/osa/domain/validation/model/hook_result.py
@@ -111,3 +111,21 @@ class HookExecution(ValueObject):
             error_message=str(failure),
             log_text=failure.container_logs,
         )
+
+    def as_failure(self) -> RuntimeFailure:
+        """Rehydrate the observed failure facts, so the FailurePolicy can decide.
+
+        The inverse of :meth:`failed`: an errored execution flattened a
+        :class:`RuntimeFailure` into value-object fields for provenance; this
+        reconstructs the facts the policy consults (kind + detail + bump count).
+        ``container_logs`` and ``exit_code`` are not round-tripped — the policy
+        never reads them, and the ingest hook path discards the resulting
+        give-up reason (provenance uses ``error_message``).
+        """
+        if self.failure is None:
+            raise ValueError(f"hook {self.hook_name!r} did not error — no failure to rehydrate")
+        return RuntimeFailure(
+            self.failure,
+            self.error_message or "",
+            oom_retries=self.oom_retries,
+        )

--- a/server/osa/domain/validation/service/hook.py
+++ b/server/osa/domain/validation/service/hook.py
@@ -1,7 +1,8 @@
 """HookService — executes hooks with OOM retry and checkpointing.
 
 Handles both single-record (deposition) and multi-record (ingestion) batches.
-On OOM, retries with doubled memory up to MAX_OOM_RETRIES times.
+On OOM, the injected FailurePolicy decides whether to retry with doubled
+memory or give up (#152) — the budget lives in the policy, not here.
 Checkpoints partial progress so crash recovery skips completed records.
 
 Sorting assumption: hooks process records in input order and write output
@@ -14,7 +15,13 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 
-from osa.domain.shared.error import OOMError, PermanentError, TransientError
+from osa.domain.shared.failure import (
+    FailureKind,
+    FailurePolicy,
+    PriorAttempts,
+    RetryWithMoreMemory,
+    RuntimeFailure,
+)
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.service import Service
 from osa.domain.validation.model.hook_release import HookRelease
@@ -31,14 +38,13 @@ from osa.infrastructure.logging import get_logger
 
 log = get_logger(__name__)
 
-MAX_OOM_RETRIES = 3
-
 
 class HookService(Service):
     """Executes a hook with OOM retry, checkpointing, and finalization."""
 
     hook_runner: HookRunner
     hook_storage: HookStoragePort
+    failure_policy: FailurePolicy
 
     async def run_hook(
         self,
@@ -50,8 +56,9 @@ class HookService(Service):
         """Run a single hook against a batch of records, retrying on OOM.
 
         Returns the final HookResult. On success or non-OOM failure, returns
-        after the first attempt. On OOM, retries with doubled memory up to
-        MAX_OOM_RETRIES times, checkpointing partial progress between attempts.
+        after the first attempt. On OOM, consults the FailurePolicy: retry with
+        doubled memory while the bump budget lasts, checkpointing partial
+        progress between attempts; then give up with the real bump count.
         """
         records = inputs.records
         if not records:
@@ -78,7 +85,7 @@ class HookService(Service):
         total_duration = 0.0
         oom_retries = 0
 
-        for attempt in range(1 + MAX_OOM_RETRIES):
+        while True:
             attempt_inputs = HookInputs(
                 records=remaining,
                 run_id=inputs.run_id,
@@ -88,7 +95,11 @@ class HookService(Service):
 
             try:
                 result = await self.hook_runner.run(hook, current_release, attempt_inputs, work_dir)
-            except OOMError as exc:
+            except RuntimeFailure as exc:
+                if exc.kind is not FailureKind.OOM:
+                    # Non-OOM failures propagate; disposition is decided upstream.
+                    raise
+
                 # Read any partial output written before OOM
                 new_outcomes = _read_output_dir(work_dir)
                 for rid, outcome in new_outcomes.items():
@@ -102,37 +113,37 @@ class HookService(Service):
                 if not remaining:
                     break
 
-                if attempt < MAX_OOM_RETRIES:
+                decision = self.failure_policy.decide(exc, PriorAttempts(memory_bumps=oom_retries))
+                if isinstance(decision, RetryWithMoreMemory):
                     current_release = current_release.with_doubled_memory()
                     oom_retries += 1
                     log.info(
                         "OOM retry {attempt}/{max_retries} for hook={hook_name}, memory={memory}, remaining={remaining} records",
-                        attempt=attempt + 1,
-                        max_retries=MAX_OOM_RETRIES,
+                        attempt=oom_retries,
+                        max_retries=self.failure_policy.max_memory_bumps,
                         hook_name=hook.name,
                         memory=current_release.runtime.limits.memory,
                         remaining=len(remaining),
                     )
                     continue
-                else:
-                    # Exhausted retries — mark remaining as errored
-                    for r in remaining:
-                        outcomes[HookRecordId(r.id)] = BatchRecordOutcome(
-                            record_id=HookRecordId(r.id),
-                            status=OutcomeStatus.ERRORED,
-                            error=f"OOM after {MAX_OOM_RETRIES} retries (last limit: {current_release.runtime.limits.memory})",
-                        )
-                    await self.hook_storage.write_batch_outcomes(work_dir, outcomes)
-                    # Surface the real retry count so the batch wrapper can record
-                    # it on the failed execution's provenance.
-                    raise OOMError(
-                        f"OOM after {oom_retries} retries "
-                        f"(last limit: {current_release.runtime.limits.memory})",
-                        oom_retries=oom_retries,
-                        container_logs=exc.container_logs,
+
+                # Bump budget spent — mark remaining as errored and give up.
+                for r in remaining:
+                    outcomes[HookRecordId(r.id)] = BatchRecordOutcome(
+                        record_id=HookRecordId(r.id),
+                        status=OutcomeStatus.ERRORED,
+                        error=f"OOM after {oom_retries} retries (last limit: {current_release.runtime.limits.memory})",
                     )
-            # Non-OOM exceptions (TransientError, PermanentError, etc.)
-            # propagate uncaught to the worker layer
+                await self.hook_storage.write_batch_outcomes(work_dir, outcomes)
+                # Surface the real retry count so the batch wrapper can record
+                # it on the failed execution's provenance.
+                raise RuntimeFailure(
+                    FailureKind.OOM,
+                    f"OOM after {oom_retries} retries "
+                    f"(last limit: {current_release.runtime.limits.memory})",
+                    oom_retries=oom_retries,
+                    container_logs=exc.container_logs,
+                )
 
             total_duration += result.duration_seconds
 
@@ -179,9 +190,10 @@ class HookService(Service):
         this run (snapshot, R8). work_dirs maps hook_name → output directory.
 
         Errors are **values, not control flow**: a hook that raises is caught and
-        recorded as a failed :class:`HookExecution` (with its FailureKind) rather
-        than aborting the batch — so a failing hook never discards its siblings'
-        outcomes. Each execution carries *its own* wall-clock window.
+        recorded as a failed :class:`HookExecution` (with its observed cause
+        FailureKind) rather than aborting the batch — so a failing hook never
+        discards its siblings' outcomes. Each execution carries *its own*
+        wall-clock window.
         """
         executions: list[HookExecution] = []
         for hook, release in hook_releases:
@@ -193,7 +205,7 @@ class HookService(Service):
                 executions.append(
                     HookExecution.completed(hook, release, result, started_at, finished_at)
                 )
-            except (OOMError, TransientError, PermanentError) as exc:
+            except RuntimeFailure as exc:
                 finished_at = datetime.now(UTC)
                 executions.append(HookExecution.failed(hook, release, exc, started_at, finished_at))
         return executions

--- a/server/osa/domain/validation/service/validation.py
+++ b/server/osa/domain/validation/service/validation.py
@@ -7,7 +7,8 @@ from uuid import uuid4
 
 from typing import Any
 
-from osa.domain.shared.error import InfrastructureError, NotFoundError, OOMError
+from osa.domain.shared.error import NotFoundError
+from osa.domain.shared.failure import FailurePolicy, RuntimeFailure
 from osa.domain.shared.model.hook import HookIdentity, HookName
 from osa.domain.shared.model.srn import (
     ConventionSlug,
@@ -41,6 +42,7 @@ class ValidationService(Service):
     hook_runner: HookRunner
     hook_storage: HookStoragePort
     hook_registry: HookRegistryService
+    failure_policy: FailurePolicy
     node_domain: Domain
 
     async def create_run(
@@ -86,6 +88,7 @@ class ValidationService(Service):
         hook_service = HookService(
             hook_runner=self.hook_runner,
             hook_storage=self.hook_storage,
+            failure_policy=self.failure_policy,
         )
 
         # Resolve identity + live release per hook (snapshot).
@@ -110,18 +113,18 @@ class ValidationService(Service):
             except Exception as exc:
                 finished_at = datetime.now(timezone.utc)
                 # Record ANY failure as a terminal ERROR run. Capture the failed
-                # container's logs (typed on InfrastructureError, else the message)
+                # container's logs (typed on RuntimeFailure, else the message)
                 # to a tenant-scoped artifact so the ERROR is diagnosable (#145/#147).
                 text = (
                     exc.container_logs
-                    if isinstance(exc, InfrastructureError) and exc.container_logs
+                    if isinstance(exc, RuntimeFailure) and exc.container_logs
                     else str(exc)
                 )
                 log_ref = await self.hook_storage.write_hook_log(work_dir, text)
-                # run_hook re-raises OOMError carrying the real retry count after
-                # exhausting memory retries — record it, don't zero it (mirrors
-                # the batch path's HookExecution.failed). Non-OOM failures: 0.
-                oom_retries = exc.oom_retries or 0 if isinstance(exc, OOMError) else 0
+                # run_hook re-raises the OOM RuntimeFailure carrying the real bump
+                # count after exhausting memory retries — record it, don't zero it
+                # (mirrors the batch path's HookExecution.failed). Other errors: 0.
+                oom_retries = exc.oom_retries if isinstance(exc, RuntimeFailure) else 0
                 await self.hook_registry.record_run(
                     HookRun(
                         id=run_id,

--- a/server/osa/domain/validation/util/di/provider.py
+++ b/server/osa/domain/validation/util/di/provider.py
@@ -1,6 +1,7 @@
 from dishka import provide
 
 from osa.config import Config
+from osa.domain.shared.failure import FailurePolicy
 from osa.domain.shared.model.srn import Domain
 from osa.domain.validation.command.create_release import CreateReleaseHandler
 from osa.domain.validation.command.set_live import SetLiveHandler
@@ -39,3 +40,8 @@ class ValidationProvider(Provider):
     @provide(scope=Scope.UOW)
     def get_node_domain(self, config: Config) -> Domain:
         return Domain(config.domain)
+
+    @provide(scope=Scope.APP)
+    def get_failure_policy(self) -> FailurePolicy:
+        """The one place runtime-failure disposition rules live (#152)."""
+        return FailurePolicy()

--- a/server/osa/infrastructure/ingest/di.py
+++ b/server/osa/infrastructure/ingest/di.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from osa.config import Config
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.ingest.command.start_ingest import StartIngestHandler
+from osa.domain.ingest.query.get_ingestion import GetIngestionHandler
 from osa.infrastructure.s3.client import S3Client
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.ingest.port.storage import IngestStoragePort
@@ -66,3 +67,4 @@ class IngestProvider(Provider):
         )
 
     start_ingest_handler = provide(StartIngestHandler, scope=Scope.UOW)
+    get_ingestion_handler = provide(GetIngestionHandler, scope=Scope.UOW)

--- a/server/osa/infrastructure/k8s/errors.py
+++ b/server/osa/infrastructure/k8s/errors.py
@@ -1,29 +1,31 @@
 """K8s API error classification.
 
-Maps kubernetes-asyncio ApiException status codes to OSA error types.
+Maps kubernetes-asyncio ApiException status codes to runtime-failure facts.
+Disposition (retry / give up / abort) is the FailurePolicy's call, not ours.
 """
 
-from osa.domain.shared.error import OSAError, PermanentError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 
 
-def classify_api_error(exc: Exception) -> OSAError:
+def classify_api_error(exc: Exception) -> RuntimeFailure:
     """Classify a K8s API error by HTTP status code.
 
-    - 403 → PermanentError (RBAC misconfiguration, not retried)
-    - 404 → PermanentError (namespace/resource missing, not retried)
-    - 500, 503 → TransientError (cluster pressure, retried with backoff)
-    - Other → TransientError
+    - 403 → RBAC (ServiceAccount misconfiguration)
+    - 404 → CONFIG (namespace/resource missing)
+    - anything else → RUNTIME (cluster pressure, API hiccup)
     """
     status = getattr(exc, "status", 0)
     reason = getattr(exc, "reason", str(exc))
 
     if status == 403:
-        return PermanentError(
+        return RuntimeFailure(
+            FailureKind.RBAC,
             f"K8s RBAC permission denied: {reason}. "
-            "Check ServiceAccount permissions for the OSA namespace."
+            "Check ServiceAccount permissions for the OSA namespace.",
         )
     if status == 404:
-        return PermanentError(
-            f"K8s resource not found: {reason}. Check that the namespace and resources exist."
+        return RuntimeFailure(
+            FailureKind.CONFIG,
+            f"K8s resource not found: {reason}. Check that the namespace and resources exist.",
         )
-    return TransientError(f"K8s API error ({status}): {reason}")
+    return RuntimeFailure(FailureKind.RUNTIME, f"K8s API error ({status}): {reason}")

--- a/server/osa/infrastructure/k8s/ingester_runner.py
+++ b/server/osa/infrastructure/k8s/ingester_runner.py
@@ -9,12 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from osa.config import K8sConfig
-from osa.domain.shared.error import (
-    InfrastructureError,
-    OOMError,
-    PermanentError,
-    TransientError,
-)
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.source import IngesterDefinition
 from osa.domain.shared.model.srn import ConventionSlug
 from osa.domain.shared.port.ingester_runner import IngesterInputs, IngesterOutput, IngesterRunner
@@ -189,7 +184,7 @@ class K8sIngesterRunner(IngesterRunner):
             )
             return output
 
-        except InfrastructureError as e:
+        except RuntimeFailure as e:
             # Capture logs before cleanup destroys the pod
             if job_name_to_watch:
                 logs = await self._capture_pod_logs(job_name_to_watch, namespace)
@@ -396,14 +391,17 @@ class K8sIngesterRunner(IngesterRunner):
                 phase = pod.status.phase
                 if phase == "Failed":
                     reason = getattr(pod.status, "reason", None) or "Unknown"
-                    raise TransientError(f"Pod failed during scheduling: {reason}")
+                    raise RuntimeFailure(
+                        FailureKind.RUNTIME, f"Pod failed during scheduling: {reason}"
+                    )
 
                 if phase == "Pending" and pod.status.container_statuses:
                     for cs in pod.status.container_statuses:
                         waiting = getattr(cs.state, "waiting", None)
                         if waiting and waiting.reason in ("ImagePullBackOff", "ErrImagePull"):
-                            raise PermanentError(
-                                f"Image pull failed: {waiting.reason}: {getattr(waiting, 'message', '')}"
+                            raise RuntimeFailure(
+                                FailureKind.IMAGE_PULL,
+                                f"Image pull failed: {waiting.reason}: {getattr(waiting, 'message', '')}",
                             )
 
                 if phase in ("Running", "Succeeded", "Failed"):
@@ -411,7 +409,10 @@ class K8sIngesterRunner(IngesterRunner):
 
             await asyncio.sleep(poll_interval)
 
-        raise TransientError(f"Pod scheduling timeout after {timeout_seconds}s for Job {job_name}")
+        raise RuntimeFailure(
+            FailureKind.TIMEOUT,
+            f"Pod scheduling timeout after {timeout_seconds}s for Job {job_name}",
+        )
 
     async def _wait_for_completion(
         self,
@@ -452,7 +453,9 @@ class K8sIngesterRunner(IngesterRunner):
         except Exception:
             pass
 
-        raise TransientError(f"Watch timeout waiting for ingester Job {job_name} completion")
+        raise RuntimeFailure(
+            FailureKind.TIMEOUT, f"Watch timeout waiting for ingester Job {job_name} completion"
+        )
 
     async def _capture_pod_logs(self, job_name: str, namespace: str) -> str:
         """Capture tail logs from a Job's pod. Returns empty if unavailable."""
@@ -474,10 +477,10 @@ class K8sIngesterRunner(IngesterRunner):
         job_name: str,
         namespace: str,
         failure_info: str,
-    ) -> InfrastructureError:
-        """Inspect pod status, capture logs, and return the appropriate exception."""
+    ) -> RuntimeFailure:
+        """Inspect pod status and return the observed failure facts."""
         if "DeadlineExceeded" in failure_info:
-            return TransientError("Ingester timed out (deadline exceeded)")
+            return RuntimeFailure(FailureKind.TIMEOUT, "Ingester timed out (deadline exceeded)")
 
         try:
             label_selector = f"job-name={job_name}"
@@ -490,17 +493,21 @@ class K8sIngesterRunner(IngesterRunner):
                         terminated = getattr(cs.state, "terminated", None)
                         if terminated:
                             if getattr(terminated, "reason", None) == "OOMKilled":
-                                return OOMError("Source killed by OOM")
+                                return RuntimeFailure(FailureKind.OOM, "Source killed by OOM")
                             exit_code = getattr(terminated, "exit_code", -1)
                             if exit_code != 0:
-                                # Transient: ingester non-zero exit is often an upstream
+                                # UPSTREAM: ingester non-zero exit is often an upstream
                                 # API failure (500, rate limit), not a code bug.
-                                # Contrast with hooks where non-zero = PermanentError.
-                                return TransientError(f"Source exited with code {exit_code}")
+                                # Contrast with hooks where non-zero = HOOK_EXIT.
+                                return RuntimeFailure(
+                                    FailureKind.UPSTREAM,
+                                    f"Source exited with code {exit_code}",
+                                    exit_code=exit_code,
+                                )
         except Exception:
             pass
 
-        return PermanentError(f"Source failed: {failure_info}")
+        return RuntimeFailure(FailureKind.UNKNOWN, f"Source failed: {failure_info}")
 
     async def _cleanup_job(self, job_name: str, namespace: str) -> None:
         try:

--- a/server/osa/infrastructure/k8s/runner.py
+++ b/server/osa/infrastructure/k8s/runner.py
@@ -9,12 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from osa.config import K8sConfig
-from osa.domain.shared.error import (
-    InfrastructureError,
-    OOMError,
-    PermanentError,
-    TransientError,
-)
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.hook import HookIdentity
 from osa.domain.validation.model.hook_release import HookRelease
 from osa.domain.validation.model.hook_result import HookResult, HookStatus
@@ -170,7 +165,7 @@ class K8sHookRunner(HookRunner):
 
             return await self._parse_hook_result(hook, work_dir, start_time)
 
-        except InfrastructureError as e:
+        except RuntimeFailure as e:
             # Capture logs before cleanup destroys the pod
             if job_name_to_watch:
                 logs = await self._capture_pod_logs(job_name_to_watch, namespace)
@@ -409,7 +404,10 @@ class K8sHookRunner(HookRunner):
                 # Check for eviction
                 if phase == "Failed":
                     reason = getattr(pod.status, "reason", None) or "Unknown"
-                    raise TransientError(f"Pod evicted or failed during scheduling: {reason}")
+                    raise RuntimeFailure(
+                        FailureKind.RUNTIME,
+                        f"Pod evicted or failed during scheduling: {reason}",
+                    )
 
                 # Check for image pull errors
                 if phase == "Pending" and pod.status.container_statuses:
@@ -417,14 +415,20 @@ class K8sHookRunner(HookRunner):
                         waiting = getattr(cs.state, "waiting", None)
                         if waiting and waiting.reason in ("ImagePullBackOff", "ErrImagePull"):
                             message = getattr(waiting, "message", "")
-                            raise PermanentError(f"Image pull failed: {waiting.reason}: {message}")
+                            raise RuntimeFailure(
+                                FailureKind.IMAGE_PULL,
+                                f"Image pull failed: {waiting.reason}: {message}",
+                            )
 
                 if phase in ("Running", "Succeeded", "Failed"):
                     return  # Pod scheduled
 
             await asyncio.sleep(poll_interval)
 
-        raise TransientError(f"Pod scheduling timeout after {timeout_seconds}s for Job {job_name}")
+        raise RuntimeFailure(
+            FailureKind.TIMEOUT,
+            f"Pod scheduling timeout after {timeout_seconds}s for Job {job_name}",
+        )
 
     async def _wait_for_completion(
         self,
@@ -467,7 +471,9 @@ class K8sHookRunner(HookRunner):
         except Exception:
             pass
 
-        raise TransientError(f"Watch timeout waiting for Job {job_name} completion")
+        raise RuntimeFailure(
+            FailureKind.TIMEOUT, f"Watch timeout waiting for Job {job_name} completion"
+        )
 
     async def _capture_pod_logs(self, job_name: str, namespace: str) -> str:
         """Capture tail logs from a Job's pod. Returns empty if unavailable."""
@@ -489,10 +495,10 @@ class K8sHookRunner(HookRunner):
         job_name: str,
         namespace: str,
         failure_info: str,
-    ) -> InfrastructureError:
-        """Inspect pod status, capture logs, and return the appropriate exception."""
+    ) -> RuntimeFailure:
+        """Inspect pod status and return the observed failure facts."""
         if "DeadlineExceeded" in failure_info:
-            return TransientError("Hook timed out (deadline exceeded)")
+            return RuntimeFailure(FailureKind.TIMEOUT, "Hook timed out (deadline exceeded)")
 
         try:
             label_selector = f"job-name={job_name}"
@@ -505,14 +511,18 @@ class K8sHookRunner(HookRunner):
                         terminated = getattr(cs.state, "terminated", None)
                         if terminated:
                             if getattr(terminated, "reason", None) == "OOMKilled":
-                                return OOMError("Hook killed by OOM")
+                                return RuntimeFailure(FailureKind.OOM, "Hook killed by OOM")
                             exit_code = getattr(terminated, "exit_code", -1)
                             if exit_code != 0:
-                                return PermanentError(f"Hook exited with code {exit_code}")
+                                return RuntimeFailure(
+                                    FailureKind.HOOK_EXIT,
+                                    f"Hook exited with code {exit_code}",
+                                    exit_code=exit_code,
+                                )
         except Exception:
             pass
 
-        return PermanentError(f"Hook failed: {failure_info}")
+        return RuntimeFailure(FailureKind.UNKNOWN, f"Hook failed: {failure_info}")
 
     async def _cleanup_job(
         self,

--- a/server/osa/infrastructure/oci/ingester_runner.py
+++ b/server/osa/infrastructure/oci/ingester_runner.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 
 import aiodocker
-from osa.domain.shared.error import OOMError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.infrastructure.logging import get_logger
 from osa.domain.shared.model.source import IngesterDefinition
 from osa.domain.shared.port.ingester_runner import IngesterInputs, IngesterOutput, IngesterRunner
@@ -108,7 +108,7 @@ class OciIngesterRunner(IngesterRunner):
                     timeout=timeout,
                     duration=duration,
                 )
-                raise TransientError(f"Ingester timed out after {timeout}s")
+                raise RuntimeFailure(FailureKind.TIMEOUT, f"Ingester timed out after {timeout}s")
         finally:
             rmtree(staging_dir, onexc=_force_remove)
 
@@ -169,7 +169,7 @@ class OciIngesterRunner(IngesterRunner):
             oom_killed = inspect_data.get("State", {}).get("OOMKilled", False)
 
             if oom_killed:
-                raise OOMError("Ingester killed by OOM")
+                raise RuntimeFailure(FailureKind.OOM, "Ingester killed by OOM")
 
             if exit_code != 0:
                 # Tenant container output (which can carry upstream credentials /
@@ -186,7 +186,13 @@ class OciIngesterRunner(IngesterRunner):
                     exit_code=exit_code,
                     image=ingester.image,
                 )
-                raise TransientError(f"Ingester exited with code {exit_code}")
+                # UPSTREAM: ingester non-zero exit is usually an upstream API
+                # failure (500, rate limit), not a code bug.
+                raise RuntimeFailure(
+                    FailureKind.UPSTREAM,
+                    f"Ingester exited with code {exit_code}",
+                    exit_code=exit_code,
+                )
 
             records = parse_records_file(output_dir)
             session = parse_session_file(output_dir)
@@ -194,7 +200,7 @@ class OciIngesterRunner(IngesterRunner):
 
         except aiodocker.DockerError as e:
             log.error("Docker error running ingester: {error}", error=str(e))
-            raise TransientError(f"Docker error: {e}") from e
+            raise RuntimeFailure(FailureKind.RUNTIME, f"Docker error: {e}") from e
         finally:
             if container is not None:
                 try:
@@ -237,5 +243,8 @@ class OciIngesterRunner(IngesterRunner):
 
         # Pull from registry as last resort
         log.info("Pulling ingester image: {image}", image=image)
-        await self._docker.images.pull(image)
+        try:
+            await self._docker.images.pull(image)
+        except aiodocker.DockerError as e:
+            raise RuntimeFailure(FailureKind.IMAGE_PULL, f"Image pull failed: {e}") from e
         return image

--- a/server/osa/infrastructure/oci/runner.py
+++ b/server/osa/infrastructure/oci/runner.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from shutil import rmtree
 
 import aiodocker
-from osa.domain.shared.error import OOMError, PermanentError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.hook import HookIdentity
 from osa.domain.validation.model.hook_release import HookRelease
 from osa.domain.validation.model.hook_result import HookResult, HookStatus
@@ -114,7 +114,7 @@ class OciHookRunner(HookRunner):
                     run_id=inputs.run_id,
                     timeout=timeout,
                 )
-                raise TransientError(f"Hook timed out after {timeout}s")
+                raise RuntimeFailure(FailureKind.TIMEOUT, f"Hook timed out after {timeout}s")
         finally:
             rmtree(staging_dir, onexc=_force_remove)
 
@@ -193,7 +193,8 @@ class OciHookRunner(HookRunner):
                     hook_name=hook.name,
                     memory=release.runtime.limits.memory,
                 )
-                raise OOMError(
+                raise RuntimeFailure(
+                    FailureKind.OOM,
                     f"Hook killed by OOM (limit: {release.runtime.limits.memory})",
                     container_logs=oom_text,
                 )
@@ -213,8 +214,10 @@ class OciHookRunner(HookRunner):
             if exit_code != 0:
                 logs = await container.log(stdout=True, stderr=True)
                 logs_str = "".join(logs) if logs else None
-                raise PermanentError(
+                raise RuntimeFailure(
+                    FailureKind.HOOK_EXIT,
                     f"Hook exited with code {exit_code}",
+                    exit_code=exit_code,
                     container_logs=logs_str,
                 )
 
@@ -223,14 +226,14 @@ class OciHookRunner(HookRunner):
                 "progress": progress,
             }
 
-        except (OOMError, PermanentError):
+        except RuntimeFailure:
             raise
         except aiodocker.DockerError as e:
             log.error("Docker error running hook", error=str(e))
-            raise TransientError(f"Docker error: {e}") from e
+            raise RuntimeFailure(FailureKind.RUNTIME, f"Docker error: {e}") from e
         except Exception as e:
             log.error("Unexpected error running hook", error=str(e))
-            raise TransientError(f"Unexpected error: {e}") from e
+            raise RuntimeFailure(FailureKind.RUNTIME, f"Unexpected error: {e}") from e
         finally:
             if container is not None:
                 try:
@@ -268,5 +271,8 @@ class OciHookRunner(HookRunner):
 
         # Pull from registry as last resort
         log.info("Pulling hook image", image=image)
-        await self._docker.images.pull(image)
+        try:
+            await self._docker.images.pull(image)
+        except aiodocker.DockerError as e:
+            raise RuntimeFailure(FailureKind.IMAGE_PULL, f"Image pull failed: {e}") from e
         return image

--- a/server/osa/infrastructure/persistence/repository/ingest.py
+++ b/server/osa/infrastructure/persistence/repository/ingest.py
@@ -3,16 +3,27 @@
 import logging
 from datetime import datetime
 
-from sqlalchemy import select, update
+from sqlalchemy import RowMapping, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from osa.domain.ingest.model.ingest_run import IngestRun, IngestStatus
+from osa.domain.ingest.model.ingest_run import (
+    Applied,
+    IngestRun,
+    IngestStatus,
+    RunClosed,
+    RunUpdate,
+)
 from osa.domain.ingest.port.repository import IngestRunRepository
+from osa.domain.shared.error import NotFoundError
 from osa.domain.shared.failure import FailureKind
 from osa.infrastructure.persistence.tables import ingest_runs_table
 
 logger = logging.getLogger(__name__)
+
+# Counter/state mutations only apply while a run is non-terminal — a stale batch
+# that finishes after abort_run/completion must not mutate the closed run (#152).
+_NON_TERMINAL = (IngestStatus.PENDING.value, IngestStatus.RUNNING.value)
 
 
 class PostgresIngestRunRepository(IngestRunRepository):
@@ -75,10 +86,26 @@ class PostgresIngestRunRepository(IngestRunRepository):
             return None
         return _row_to_ingest_run(dict(row))
 
+    async def _applied_or_closed(self, row: RowMapping | None, id: str) -> RunUpdate:
+        """Interpret a status-guarded UPDATE's RETURNING row (#152).
+
+        A row means the mutation landed → :class:`Applied`. Zero rows means the
+        guard rejected it: distinguish an already-terminal run (an expected
+        concurrent no-op → :class:`RunClosed`) from a genuinely-missing run (a
+        bug → ``NotFoundError``). The classifying read runs only on the miss and
+        is race-stable — runs are neither created-with-this-id nor deleted
+        concurrently.
+        """
+        if row is not None:
+            return Applied(run=_row_to_ingest_run(dict(row)))
+        if await self.get(id) is None:
+            raise NotFoundError(f"Ingest run not found: {id}")
+        return RunClosed()
+
     async def increment_batches_ingested(
         self, id: str, *, set_ingestion_finished: bool = False
-    ) -> IngestRun:
-        """Atomically increment batches_ingested."""
+    ) -> RunUpdate:
+        """Atomically increment batches_ingested while the run is non-terminal (#152)."""
         t = ingest_runs_table
         values = {
             "batches_ingested": t.c.batches_ingested + 1,
@@ -86,40 +113,42 @@ class PostgresIngestRunRepository(IngestRunRepository):
         if set_ingestion_finished:
             values["ingestion_finished"] = True
 
-        stmt = update(t).where(t.c.id == id).values(**values).returning(*t.c)
+        stmt = (
+            update(t)
+            .where(t.c.id == id)
+            .where(t.c.status.in_(_NON_TERMINAL))
+            .values(**values)
+            .returning(*t.c)
+        )
         result = await self._session.execute(stmt)
         await self._session.flush()
-        row = result.mappings().first()
-        if row is None:
-            from osa.domain.shared.error import NotFoundError
+        return await self._applied_or_closed(result.mappings().first(), id)
 
-            raise NotFoundError(f"Ingest run not found: {id}")
-        return _row_to_ingest_run(dict(row))
+    async def increment_failed(self, id: str) -> RunUpdate:
+        """Atomically increment batches_failed while the run is non-terminal (#152).
 
-    async def increment_failed(self, id: str) -> IngestRun:
-        """Atomically increment batches_failed."""
+        A stale batch that exhausts after abort must not accumulate failures on
+        the closed run — the guard makes that a :class:`RunClosed` no-op.
+        """
         t = ingest_runs_table
         stmt = (
             update(t)
             .where(t.c.id == id)
+            .where(t.c.status.in_(_NON_TERMINAL))
             .values(batches_failed=t.c.batches_failed + 1)
             .returning(*t.c)
         )
         result = await self._session.execute(stmt)
         await self._session.flush()
-        row = result.mappings().first()
-        if row is None:
-            from osa.domain.shared.error import NotFoundError
+        return await self._applied_or_closed(result.mappings().first(), id)
 
-            raise NotFoundError(f"Ingest run not found: {id}")
-        return _row_to_ingest_run(dict(row))
-
-    async def increment_completed(self, id: str, published_count: int) -> IngestRun:
-        """Atomically increment batches_completed and published_count."""
+    async def increment_completed(self, id: str, published_count: int) -> RunUpdate:
+        """Atomically increment batches_completed and published_count, non-terminal only (#152)."""
         t = ingest_runs_table
         stmt = (
             update(t)
             .where(t.c.id == id)
+            .where(t.c.status.in_(_NON_TERMINAL))
             .values(
                 batches_completed=t.c.batches_completed + 1,
                 published_count=t.c.published_count + published_count,
@@ -128,12 +157,7 @@ class PostgresIngestRunRepository(IngestRunRepository):
         )
         result = await self._session.execute(stmt)
         await self._session.flush()
-        row = result.mappings().first()
-        if row is None:
-            from osa.domain.shared.error import NotFoundError
-
-            raise NotFoundError(f"Ingest run not found: {id}")
-        return _row_to_ingest_run(dict(row))
+        return await self._applied_or_closed(result.mappings().first(), id)
 
     async def abort(
         self,
@@ -142,13 +166,16 @@ class PostgresIngestRunRepository(IngestRunRepository):
         reason: str,
         kind: FailureKind,
         completed_at: datetime,
-    ) -> IngestRun | None:
-        """Fail a non-terminal run with its explanation, in one guarded UPDATE."""
+    ) -> RunUpdate:
+        """Fail a non-terminal run with its explanation, in one guarded UPDATE (#152).
+
+        :class:`RunClosed` when another worker terminalized it first (idempotent).
+        """
         t = ingest_runs_table
         stmt = (
             update(t)
             .where(t.c.id == id)
-            .where(t.c.status.in_([IngestStatus.PENDING.value, IngestStatus.RUNNING.value]))
+            .where(t.c.status.in_(_NON_TERMINAL))
             .values(
                 status=IngestStatus.FAILED.value,
                 failure_reason=reason,
@@ -160,10 +187,7 @@ class PostgresIngestRunRepository(IngestRunRepository):
         )
         result = await self._session.execute(stmt)
         await self._session.flush()
-        row = result.mappings().first()
-        if row is None:
-            return None
-        return _row_to_ingest_run(dict(row))
+        return await self._applied_or_closed(result.mappings().first(), id)
 
     async def record_failure(self, id: str, *, reason: str, kind: FailureKind | None) -> None:
         """Record why a run failed / ingestion stopped early, without touching status.

--- a/server/osa/infrastructure/persistence/repository/ingest.py
+++ b/server/osa/infrastructure/persistence/repository/ingest.py
@@ -1,6 +1,7 @@
 """PostgreSQL implementation of IngestRunRepository."""
 
 import logging
+from datetime import datetime
 
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert
@@ -8,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from osa.domain.ingest.model.ingest_run import IngestRun, IngestStatus
 from osa.domain.ingest.port.repository import IngestRunRepository
+from osa.domain.shared.failure import FailureKind
 from osa.infrastructure.persistence.tables import ingest_runs_table
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,8 @@ class PostgresIngestRunRepository(IngestRunRepository):
             "record_limit": ingest_run.limit,
             "started_at": ingest_run.started_at,
             "completed_at": ingest_run.completed_at,
+            "failure_reason": ingest_run.failure_reason,
+            "failure_kind": ingest_run.failure_kind.value if ingest_run.failure_kind else None,
         }
         stmt = (
             insert(ingest_runs_table)
@@ -131,8 +135,53 @@ class PostgresIngestRunRepository(IngestRunRepository):
             raise NotFoundError(f"Ingest run not found: {id}")
         return _row_to_ingest_run(dict(row))
 
+    async def abort(
+        self,
+        id: str,
+        *,
+        reason: str,
+        kind: FailureKind,
+        completed_at: datetime,
+    ) -> IngestRun | None:
+        """Fail a non-terminal run with its explanation, in one guarded UPDATE."""
+        t = ingest_runs_table
+        stmt = (
+            update(t)
+            .where(t.c.id == id)
+            .where(t.c.status.in_([IngestStatus.PENDING.value, IngestStatus.RUNNING.value]))
+            .values(
+                status=IngestStatus.FAILED.value,
+                failure_reason=reason,
+                failure_kind=kind.value,
+                ingestion_finished=True,
+                completed_at=completed_at,
+            )
+            .returning(*t.c)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        row = result.mappings().first()
+        if row is None:
+            return None
+        return _row_to_ingest_run(dict(row))
+
+    async def record_failure(self, id: str, *, reason: str, kind: FailureKind | None) -> None:
+        """Record why ingestion stopped early, without touching run status."""
+        t = ingest_runs_table
+        stmt = (
+            update(t)
+            .where(t.c.id == id)
+            .values(
+                failure_reason=reason,
+                failure_kind=kind.value if kind else None,
+            )
+        )
+        await self._session.execute(stmt)
+        await self._session.flush()
+
 
 def _row_to_ingest_run(row: dict) -> IngestRun:
+    raw_kind = row.get("failure_kind")
     return IngestRun(
         id=row["id"],
         convention_id=row["convention_id"],
@@ -146,4 +195,6 @@ def _row_to_ingest_run(row: dict) -> IngestRun:
         limit=row.get("record_limit"),
         started_at=row["started_at"],
         completed_at=row.get("completed_at"),
+        failure_reason=row.get("failure_reason"),
+        failure_kind=FailureKind(raw_kind) if raw_kind else None,
     )

--- a/server/osa/infrastructure/persistence/repository/ingest.py
+++ b/server/osa/infrastructure/persistence/repository/ingest.py
@@ -166,11 +166,17 @@ class PostgresIngestRunRepository(IngestRunRepository):
         return _row_to_ingest_run(dict(row))
 
     async def record_failure(self, id: str, *, reason: str, kind: FailureKind | None) -> None:
-        """Record why ingestion stopped early, without touching run status."""
+        """Record why a run failed / ingestion stopped early, without touching status.
+
+        First-writer-wins: the ``failure_reason IS NULL`` guard means a run
+        abort (which sets the reason via :meth:`abort`) is never clobbered by a
+        later per-batch give-up that races in behind it (#152).
+        """
         t = ingest_runs_table
         stmt = (
             update(t)
             .where(t.c.id == id)
+            .where(t.c.failure_reason.is_(None))
             .values(
                 failure_reason=reason,
                 failure_kind=kind.value if kind else None,

--- a/server/osa/infrastructure/persistence/tables.py
+++ b/server/osa/infrastructure/persistence/tables.py
@@ -365,6 +365,10 @@ ingest_runs_table = Table(
     Column("batches_failed", Integer, nullable=False, server_default=text("0")),
     Column("started_at", DateTime(timezone=True), nullable=False),
     Column("completed_at", DateTime(timezone=True), nullable=True),
+    # Why the run failed / ingestion stopped early (#152): human reason +
+    # machine FailureKind, exposed via GET /ingestions/{id}.
+    Column("failure_reason", Text, nullable=True),
+    Column("failure_kind", String(32), nullable=True),
 )
 
 Index("idx_ingest_runs_convention", ingest_runs_table.c.convention_id)

--- a/server/tests/integration/persistence/test_ingest_repo.py
+++ b/server/tests/integration/persistence/test_ingest_repo.py
@@ -10,7 +10,14 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
+from osa.domain.ingest.model.ingest_run import (
+    Applied,
+    IngestRun,
+    IngestRunId,
+    IngestStatus,
+    RunClosed,
+)
+from osa.domain.shared.error import NotFoundError
 from osa.domain.shared.failure import FailureKind
 from osa.infrastructure.persistence.repository.ingest import PostgresIngestRunRepository
 
@@ -63,7 +70,7 @@ class TestFailureSurfacing:
             kind=FailureKind.IMAGE_PULL,
             completed_at=datetime.now(UTC),
         )
-        assert aborted is not None
+        assert isinstance(aborted, Applied)
 
         # A batch that was mid-retry exhausts after the abort and records its own reason.
         await repo.record_failure(
@@ -76,3 +83,62 @@ class TestFailureSurfacing:
         assert fetched.failure_reason == "Image pull failed: 401"
         assert fetched.failure_kind is FailureKind.IMAGE_PULL
         assert fetched.status is IngestStatus.FAILED
+
+
+@pytest.mark.asyncio
+class TestTerminalRunGuard:
+    """Counter increments are no-ops once a run is terminal (#152).
+
+    A stale in-flight batch that exhausts after abort_run must not accumulate
+    failed/completed counts on the closed run — the atomic UPDATE is guarded on
+    non-terminal status, mirroring `abort`.
+    """
+
+    async def test_increment_failed_is_noop_on_terminal_run(self, pg_session: AsyncSession):
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-tf"))
+        await repo.abort(
+            "ing-tf",
+            reason="bad image",
+            kind=FailureKind.IMAGE_PULL,
+            completed_at=datetime.now(UTC),
+        )
+
+        result = await repo.increment_failed("ing-tf")
+
+        assert isinstance(result, RunClosed)  # guarded — the closed run is not mutated
+        fetched = await repo.get(IngestRunId("ing-tf"))
+        assert fetched is not None
+        assert fetched.batches_failed == 0
+        assert fetched.status is IngestStatus.FAILED
+
+    async def test_increment_completed_is_noop_on_terminal_run(self, pg_session: AsyncSession):
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-tc"))
+        await repo.abort(
+            "ing-tc", reason="rbac", kind=FailureKind.RBAC, completed_at=datetime.now(UTC)
+        )
+
+        result = await repo.increment_completed("ing-tc", published_count=5)
+
+        assert isinstance(result, RunClosed)
+        fetched = await repo.get(IngestRunId("ing-tc"))
+        assert fetched is not None
+        assert fetched.batches_completed == 0
+        assert fetched.published_count == 0
+
+    async def test_increment_still_works_on_a_running_run(self, pg_session: AsyncSession):
+        """Sanity: the guard doesn't break the normal (non-terminal) path."""
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-live"))
+
+        result = await repo.increment_failed("ing-live")
+
+        assert isinstance(result, Applied)
+        assert result.run.batches_failed == 1
+
+    async def test_increment_on_missing_run_raises(self, pg_session: AsyncSession):
+        """A genuinely-missing run is exceptional — not a RunClosed no-op."""
+        repo = PostgresIngestRunRepository(pg_session)
+        with pytest.raises(NotFoundError):
+            await repo.increment_failed("does-not-exist")

--- a/server/tests/integration/persistence/test_ingest_repo.py
+++ b/server/tests/integration/persistence/test_ingest_repo.py
@@ -1,0 +1,78 @@
+"""Integration tests for IngestRunRepository failure surfacing (#152).
+
+Covers the queryable failure columns against real PostgreSQL: `record_failure`
+round-trips reason/kind, and it must NOT clobber a reason already set (so a
+later per-batch give-up can't overwrite an earlier run abort).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
+from osa.domain.shared.failure import FailureKind
+from osa.infrastructure.persistence.repository.ingest import PostgresIngestRunRepository
+
+
+def _make_run(run_id: str = "ing-1", status: IngestStatus = IngestStatus.RUNNING) -> IngestRun:
+    return IngestRun(
+        id=IngestRunId(run_id),
+        convention_id="test-conv",
+        status=status,
+        batch_size=100,
+        batches_ingested=1,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+class TestFailureSurfacing:
+    async def test_record_failure_round_trips_reason_and_kind(self, pg_session: AsyncSession):
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-rt"))
+
+        await repo.record_failure("ing-rt", reason="source exited 3", kind=FailureKind.UPSTREAM)
+
+        fetched = await repo.get(IngestRunId("ing-rt"))
+        assert fetched is not None
+        assert fetched.failure_reason == "source exited 3"
+        assert fetched.failure_kind is FailureKind.UPSTREAM
+
+    async def test_record_failure_allows_null_kind(self, pg_session: AsyncSession):
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-null"))
+
+        await repo.record_failure("ing-null", reason="retries exhausted", kind=None)
+
+        fetched = await repo.get(IngestRunId("ing-null"))
+        assert fetched is not None
+        assert fetched.failure_reason == "retries exhausted"
+        assert fetched.failure_kind is None
+
+    async def test_record_failure_does_not_clobber_an_existing_reason(
+        self, pg_session: AsyncSession
+    ):
+        """An abort sets the reason first; a later batch give-up must not overwrite it."""
+        repo = PostgresIngestRunRepository(pg_session)
+        await repo.save(_make_run("ing-clobber"))
+
+        aborted = await repo.abort(
+            "ing-clobber",
+            reason="Image pull failed: 401",
+            kind=FailureKind.IMAGE_PULL,
+            completed_at=datetime.now(UTC),
+        )
+        assert aborted is not None
+
+        # A batch that was mid-retry exhausts after the abort and records its own reason.
+        await repo.record_failure(
+            "ing-clobber", reason="batch 5: hook retries exhausted", kind=None
+        )
+
+        fetched = await repo.get(IngestRunId("ing-clobber"))
+        assert fetched is not None
+        # The more-significant abort reason survives.
+        assert fetched.failure_reason == "Image pull failed: 401"
+        assert fetched.failure_kind is FailureKind.IMAGE_PULL
+        assert fetched.status is IngestStatus.FAILED

--- a/server/tests/unit/domain/ingest/test_get_ingestion.py
+++ b/server/tests/unit/domain/ingest/test_get_ingestion.py
@@ -1,0 +1,98 @@
+"""Tests for GetIngestion — a failed run carries a queryable explanation (#152)."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from osa.domain.auth.model.principal import Principal
+from osa.domain.auth.model.role import Role
+from osa.domain.auth.model.value import ProviderIdentity, UserId
+from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
+from osa.domain.ingest.query.get_ingestion import GetIngestion, GetIngestionHandler
+from osa.domain.shared.error import NotFoundError
+from osa.domain.shared.failure import FailureKind
+
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _principal(role: Role = Role.ADMIN) -> Principal:
+    return Principal(
+        user_id=UserId.generate(),
+        provider_identity=ProviderIdentity(provider="test", external_id="ext"),
+        roles=frozenset({role}),
+    )
+
+
+def _make_run(**overrides) -> IngestRun:
+    defaults = {
+        "id": IngestRunId("run-1"),
+        "convention_id": "test-conv",
+        "status": IngestStatus.RUNNING,
+        "batch_size": 100,
+        "started_at": _T0,
+    }
+    defaults.update(overrides)
+    return IngestRun(**defaults)
+
+
+class TestGetIngestionHandler:
+    @pytest.mark.asyncio
+    async def test_exposes_failure_reason_and_kind(self) -> None:
+        service = AsyncMock()
+        service.get_ingestion.return_value = _make_run(
+            status=IngestStatus.FAILED,
+            failure_reason="Image pull failed: 401 Unauthorized",
+            failure_kind=FailureKind.IMAGE_PULL,
+            completed_at=_T0,
+        )
+        handler = GetIngestionHandler(principal=_principal(), service=service)
+
+        result = await handler.run(GetIngestion(ingest_run_id=IngestRunId("run-1")))
+
+        assert result.status == IngestStatus.FAILED
+        assert result.failure_reason == "Image pull failed: 401 Unauthorized"
+        assert result.failure_kind is FailureKind.IMAGE_PULL
+
+    @pytest.mark.asyncio
+    async def test_healthy_run_has_no_failure_fields(self) -> None:
+        service = AsyncMock()
+        service.get_ingestion.return_value = _make_run(
+            batches_ingested=2, batches_completed=1, published_count=1000
+        )
+        handler = GetIngestionHandler(principal=_principal(), service=service)
+
+        result = await handler.run(GetIngestion(ingest_run_id=IngestRunId("run-1")))
+
+        assert result.failure_reason is None
+        assert result.failure_kind is None
+        assert result.batches_ingested == 2
+        assert result.published_count == 1000
+
+    @pytest.mark.asyncio
+    async def test_missing_run_raises_not_found(self) -> None:
+        service = AsyncMock()
+        service.get_ingestion.side_effect = NotFoundError("Ingest run not found: nope")
+        handler = GetIngestionHandler(principal=_principal(), service=service)
+
+        with pytest.raises(NotFoundError):
+            await handler.run(GetIngestion(ingest_run_id=IngestRunId("nope")))
+
+
+class TestGetIngestionService:
+    @pytest.mark.asyncio
+    async def test_service_raises_not_found_for_missing_run(self) -> None:
+        from osa.domain.ingest.service.ingest import IngestService
+        from osa.domain.shared.model.srn import Domain
+
+        repo = AsyncMock()
+        repo.get.return_value = None
+        service = IngestService(
+            ingest_repo=repo,
+            convention_service=AsyncMock(),
+            outbox=AsyncMock(),
+            node_domain=Domain("localhost"),
+        )
+
+        with pytest.raises(NotFoundError):
+            await service.get_ingestion(IngestRunId("missing"))

--- a/server/tests/unit/domain/ingest/test_ingest_run.py
+++ b/server/tests/unit/domain/ingest/test_ingest_run.py
@@ -6,6 +6,7 @@ import pytest
 
 from osa.domain.ingest.model.ingest_run import IngestRun, IngestStatus
 from osa.domain.shared.error import InvalidStateError
+from osa.domain.shared.failure import FailureKind
 
 
 def _make_run(**overrides) -> IngestRun:
@@ -32,14 +33,24 @@ class TestStatusTransitions:
 
     def test_running_to_failed(self) -> None:
         run = _make_run(status=IngestStatus.RUNNING)
-        run.mark_failed(datetime.now(UTC))
+        run.mark_failed(datetime.now(UTC), reason="image pull failed", kind=FailureKind.IMAGE_PULL)
         assert run.status == IngestStatus.FAILED
         assert run.completed_at is not None
+        # The queryable explanation (#152): a failed run says why.
+        assert run.failure_reason == "image pull failed"
+        assert run.failure_kind is FailureKind.IMAGE_PULL
+        # No more batches will be scheduled for a failed run.
+        assert run.ingestion_finished is True
 
     def test_pending_to_failed(self) -> None:
         run = _make_run()
-        run.mark_failed(datetime.now(UTC))
+        run.mark_failed(datetime.now(UTC), reason="rbac denied", kind=FailureKind.RBAC)
         assert run.status == IngestStatus.FAILED
+
+    def test_failure_fields_default_to_none(self) -> None:
+        run = _make_run()
+        assert run.failure_reason is None
+        assert run.failure_kind is None
 
     def test_completed_to_running_rejected(self) -> None:
         run = _make_run(status=IngestStatus.COMPLETED)

--- a/server/tests/unit/domain/ingest/test_ingest_service.py
+++ b/server/tests/unit/domain/ingest/test_ingest_service.py
@@ -116,3 +116,73 @@ class TestStartIngest:
             await service.start_ingest(
                 convention_id="test-conv",
             )
+
+
+class TestAbortRun:
+    """abort_run — the AbortRun verb's executor (#152): hard-stop the whole run."""
+
+    @pytest.mark.asyncio
+    async def test_aborts_via_atomic_repo_update(self) -> None:
+        from datetime import UTC, datetime
+
+        from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        service.ingest_repo.abort.return_value = IngestRun(
+            id=IngestRunId("run-1"),
+            convention_id="test-conv",
+            status=IngestStatus.FAILED,
+            failure_reason="Image pull failed: 401",
+            failure_kind=FailureKind.IMAGE_PULL,
+            started_at=datetime.now(UTC),
+        )
+
+        await service.abort_run(
+            IngestRunId("run-1"), reason="Image pull failed: 401", kind=FailureKind.IMAGE_PULL
+        )
+
+        kwargs = service.ingest_repo.abort.await_args.kwargs
+        assert service.ingest_repo.abort.await_args.args[0] == "run-1"
+        assert kwargs["reason"] == "Image pull failed: 401"
+        assert kwargs["kind"] is FailureKind.IMAGE_PULL
+        assert kwargs["completed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_abort_is_idempotent_when_run_already_terminal(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        # Repo returns None when the run was already terminal — no-op, no error.
+        service.ingest_repo.abort.return_value = None
+
+        await service.abort_run(IngestRunId("run-1"), reason="rbac denied", kind=FailureKind.RBAC)
+
+
+class TestFailIngestionRecordsReason:
+    """fail_ingestion must leave a queryable explanation on the run (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_records_failure_reason_and_kind(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        run = MagicMock()
+        run.check_completion.return_value = False
+        service.ingest_repo.increment_failed.return_value = run
+
+        await service.fail_ingestion(
+            IngestRunId("run-1"), reason="Source exited with code 3", kind=FailureKind.UPSTREAM
+        )
+
+        kwargs = service.ingest_repo.record_failure.await_args.kwargs
+        assert service.ingest_repo.record_failure.await_args.args[0] == "run-1"
+        assert kwargs["reason"] == "Source exited with code 3"
+        assert kwargs["kind"] is FailureKind.UPSTREAM
+        # Existing accounting is preserved: no more batches + one failed batch.
+        service.ingest_repo.increment_batches_ingested.assert_awaited_once_with(
+            "run-1", set_ingestion_finished=True
+        )
+        service.ingest_repo.increment_failed.assert_awaited_once_with("run-1")

--- a/server/tests/unit/domain/ingest/test_ingest_service.py
+++ b/server/tests/unit/domain/ingest/test_ingest_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from osa.domain.ingest.model.ingest_run import IngestStatus
+from osa.domain.ingest.model.ingest_run import Applied, IngestStatus, RunClosed
 from osa.domain.ingest.service.ingest import IngestService
 from osa.domain.shared.error import ConflictError, NotFoundError
 from osa.domain.shared.model.source import IngesterDefinition
@@ -129,13 +129,15 @@ class TestAbortRun:
         from osa.domain.shared.failure import FailureKind
 
         service = _make_service()
-        service.ingest_repo.abort.return_value = IngestRun(
-            id=IngestRunId("run-1"),
-            convention_id="test-conv",
-            status=IngestStatus.FAILED,
-            failure_reason="Image pull failed: 401",
-            failure_kind=FailureKind.IMAGE_PULL,
-            started_at=datetime.now(UTC),
+        service.ingest_repo.abort.return_value = Applied(
+            run=IngestRun(
+                id=IngestRunId("run-1"),
+                convention_id="test-conv",
+                status=IngestStatus.FAILED,
+                failure_reason="Image pull failed: 401",
+                failure_kind=FailureKind.IMAGE_PULL,
+                started_at=datetime.now(UTC),
+            )
         )
 
         await service.abort_run(
@@ -154,8 +156,8 @@ class TestAbortRun:
         from osa.domain.shared.failure import FailureKind
 
         service = _make_service()
-        # Repo returns None when the run was already terminal — no-op, no error.
-        service.ingest_repo.abort.return_value = None
+        # Repo returns RunClosed when the run was already terminal — no-op, no error.
+        service.ingest_repo.abort.return_value = RunClosed()
 
         await service.abort_run(IngestRunId("run-1"), reason="rbac denied", kind=FailureKind.RBAC)
 
@@ -171,7 +173,8 @@ class TestFailIngestionRecordsReason:
         service = _make_service()
         run = MagicMock()
         run.check_completion.return_value = False
-        service.ingest_repo.increment_failed.return_value = run
+        service.ingest_repo.increment_batches_ingested.return_value = Applied(run=run)
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
 
         await service.fail_ingestion(
             IngestRunId("run-1"), reason="Source exited with code 3", kind=FailureKind.UPSTREAM
@@ -198,7 +201,7 @@ class TestFailBatchRecordsReason:
         service = _make_service()
         run = MagicMock()
         run.check_completion.return_value = False
-        service.ingest_repo.increment_failed.return_value = run
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
 
         await service.fail_batch(
             IngestRunId("run-1"), reason="batch 3: hook retries exhausted", kind=None
@@ -219,7 +222,7 @@ class TestFailBatchRecordsReason:
         service = _make_service()
         run = MagicMock(id="run-1", published_count=0)
         run.check_completion.return_value = True  # run completes in this call
-        service.ingest_repo.increment_failed.return_value = run
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
 
         await service.fail_batch(IngestRunId("run-1"), reason="boom", kind=None)
 
@@ -234,7 +237,8 @@ class TestFailBatchRecordsReason:
         service = _make_service()
         run = MagicMock(id="run-1", published_count=0)
         run.check_completion.return_value = True
-        service.ingest_repo.increment_failed.return_value = run
+        service.ingest_repo.increment_batches_ingested.return_value = Applied(run=run)
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
 
         await service.fail_ingestion(
             IngestRunId("run-1"), reason="source gave up", kind=FailureKind.UNKNOWN
@@ -242,3 +246,47 @@ class TestFailBatchRecordsReason:
 
         names = [c[0] for c in service.ingest_repo.mock_calls if c[0]]
         assert names.index("save") < names.index("record_failure")
+
+
+class TestTerminalRunAccountingIsFrozen:
+    """A terminal run is immutable: late/stale batch accounting is a no-op (#152).
+
+    After abort_run marks a run FAILED, in-flight batch deliveries can still
+    reach on_exhausted; the guarded repo increments report the run as terminal
+    (RunClosed) and the service must not mutate it further.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fail_batch_is_noop_when_run_is_terminal(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        service.ingest_repo.increment_failed.return_value = RunClosed()  # guard: run terminal
+
+        await service.fail_batch(IngestRunId("run-1"), reason="late batch", kind=None)
+
+        service.ingest_repo.record_failure.assert_not_awaited()
+        service.outbox.append.assert_not_awaited()  # no IngestCompleted re-fired
+
+    @pytest.mark.asyncio
+    async def test_complete_batch_is_noop_when_run_is_terminal(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        service.ingest_repo.increment_completed.return_value = RunClosed()
+
+        await service.complete_batch(IngestRunId("run-1"), published_count=5)
+
+        service.outbox.append.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fail_ingestion_is_noop_when_run_is_terminal(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        service.ingest_repo.increment_batches_ingested.return_value = RunClosed()
+
+        await service.fail_ingestion(IngestRunId("run-1"), reason="late pull", kind=None)
+
+        service.ingest_repo.increment_failed.assert_not_awaited()
+        service.ingest_repo.record_failure.assert_not_awaited()

--- a/server/tests/unit/domain/ingest/test_ingest_service.py
+++ b/server/tests/unit/domain/ingest/test_ingest_service.py
@@ -186,3 +186,59 @@ class TestFailIngestionRecordsReason:
             "run-1", set_ingestion_finished=True
         )
         service.ingest_repo.increment_failed.assert_awaited_once_with("run-1")
+
+
+class TestFailBatchRecordsReason:
+    """A permanently-failed batch records a queryable reason (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_records_reason_via_record_failure(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        run = MagicMock()
+        run.check_completion.return_value = False
+        service.ingest_repo.increment_failed.return_value = run
+
+        await service.fail_batch(
+            IngestRunId("run-1"), reason="batch 3: hook retries exhausted", kind=None
+        )
+
+        service.ingest_repo.increment_failed.assert_awaited_once_with("run-1")
+        kwargs = service.ingest_repo.record_failure.await_args.kwargs
+        assert kwargs["reason"] == "batch 3: hook retries exhausted"
+        assert kwargs["kind"] is None
+
+    @pytest.mark.asyncio
+    async def test_record_failure_runs_after_completion_save(self) -> None:
+        """If the batch completes the run, _check_completion saves the aggregate
+        (stale failure_reason=None). record_failure must run AFTER that save, or
+        the reason gets clobbered."""
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        run = MagicMock(id="run-1", published_count=0)
+        run.check_completion.return_value = True  # run completes in this call
+        service.ingest_repo.increment_failed.return_value = run
+
+        await service.fail_batch(IngestRunId("run-1"), reason="boom", kind=None)
+
+        names = [c[0] for c in service.ingest_repo.mock_calls if c[0]]
+        assert names.index("save") < names.index("record_failure")
+
+    @pytest.mark.asyncio
+    async def test_fail_ingestion_records_reason_after_completion_save(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        run = MagicMock(id="run-1", published_count=0)
+        run.check_completion.return_value = True
+        service.ingest_repo.increment_failed.return_value = run
+
+        await service.fail_ingestion(
+            IngestRunId("run-1"), reason="source gave up", kind=FailureKind.UNKNOWN
+        )
+
+        names = [c[0] for c in service.ingest_repo.mock_calls if c[0]]
+        assert names.index("save") < names.index("record_failure")

--- a/server/tests/unit/domain/ingest/test_publish_batch.py
+++ b/server/tests/unit/domain/ingest/test_publish_batch.py
@@ -47,9 +47,11 @@ class TestPublishBatchOnExhausted:
 
         await handler.on_exhausted(event)
 
-        handler.ingest_service.fail_batch.assert_called_once_with(
-            IngestRunId("run-1"),
-        )
+        handler.ingest_service.fail_batch.assert_awaited_once()
+        call = handler.ingest_service.fail_batch.await_args
+        assert call.args[0] == IngestRunId("run-1")
+        assert "publish" in call.kwargs["reason"] and "exhausted" in call.kwargs["reason"]
+        assert call.kwargs["kind"] is None
 
     @pytest.mark.asyncio
     async def test_on_exhausted_exists(self) -> None:

--- a/server/tests/unit/domain/ingest/test_run_hooks.py
+++ b/server/tests/unit/domain/ingest/test_run_hooks.py
@@ -16,11 +16,12 @@ from osa.domain.ingest.event.events import HookBatchCompleted, IngesterBatchRead
 from osa.domain.ingest.handler.run_hooks import RunHooks, _hook_run_id
 from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
 from osa.domain.shared.error import TransientError
+from osa.domain.shared.failure import FailureKind, FailurePolicy
 from osa.domain.shared.event import EventId
 from osa.domain.shared.model.hook import HookName, OciConfig, OciLimits, TableFeatureSpec
 from osa.domain.validation.model.hook import Hook
 from osa.domain.validation.model.hook_release import HookRelease, HookReleaseId
-from osa.domain.validation.model.hook_result import FailureKind, HookExecution, HookStatus
+from osa.domain.validation.model.hook_result import HookExecution, HookStatus
 from osa.domain.validation.model.hook_run import HookRunStatus
 
 _T0 = datetime(2026, 1, 1, tzinfo=UTC)
@@ -69,7 +70,7 @@ def _failed_exec(
         started_at=start,
         finished_at=start + timedelta(seconds=2),
         duration_s=2.0,
-        oom_retries=3 if kind == FailureKind.OOM_EXHAUSTED else 0,
+        oom_retries=3 if kind == FailureKind.OOM else 0,
         failure=kind,
         error_message="boom",
         log_text=log_text,
@@ -128,6 +129,7 @@ def _make_handler(*, hook_names: tuple[str, ...] = ("pockets",), executions=None
         hook_registry=_make_registry(hook_names),
         outbox=AsyncMock(),
         ingest_storage=ingest_storage,
+        failure_policy=FailurePolicy(),
     )
 
 
@@ -144,7 +146,7 @@ class TestContinueOnError:
     async def test_failed_hook_does_not_discard_passing_sibling(self) -> None:
         execs = [
             _passed_exec("hook_a", offset=0),
-            _failed_exec("hook_b", FailureKind.PERMANENT, offset=10),
+            _failed_exec("hook_b", FailureKind.HOOK_EXIT, offset=10),
         ]
         handler = _make_handler(hook_names=("hook_a", "hook_b"), executions=execs)
 
@@ -169,7 +171,7 @@ class TestContinueOnError:
 class TestLogRefCapture:
     @pytest.mark.asyncio
     async def test_failed_hook_with_logs_records_log_ref(self) -> None:
-        execs = [_failed_exec("pockets", FailureKind.PERMANENT, log_text="traceback...")]
+        execs = [_failed_exec("pockets", FailureKind.HOOK_EXIT, log_text="traceback...")]
         handler = _make_handler(executions=execs)
         handler.ingest_storage.write_hook_log.return_value = "/data/.../output/hook.log"
 
@@ -207,7 +209,7 @@ class TestDeterministicRunId:
 class TestTransientRetry:
     @pytest.mark.asyncio
     async def test_transient_hook_raises_and_does_not_emit(self) -> None:
-        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.TRANSIENT)])
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.TIMEOUT)])
 
         with pytest.raises(TransientError):
             await handler.handle(_make_event())
@@ -221,7 +223,7 @@ class TestTransientRetry:
 class TestTerminalFailurePolicy:
     @pytest.mark.asyncio
     async def test_permanent_failure_completes_batch(self) -> None:
-        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.PERMANENT)])
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.HOOK_EXIT)])
 
         await handler.handle(_make_event())
 
@@ -231,7 +233,7 @@ class TestTerminalFailurePolicy:
 
     @pytest.mark.asyncio
     async def test_oom_exhaustion_completes_with_retry_count(self) -> None:
-        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.OOM_EXHAUSTED)])
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.OOM)])
 
         await handler.handle(_make_event())
 
@@ -239,3 +241,59 @@ class TestTerminalFailurePolicy:
         assert run.status == HookRunStatus.ERROR and run.oom_retries == 3
         assert any(isinstance(e, HookBatchCompleted) for e in _emitted(handler))
         handler.ingest_service.fail_batch.assert_not_called()
+
+
+class TestAbortOnEnvironmentalFailure:
+    """An unpullable image / RBAC / config failure dooms every batch — the
+    handler must abort the whole run instead of grinding through (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_image_pull_failure_aborts_run(self) -> None:
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.IMAGE_PULL)])
+
+        await handler.handle(_make_event())
+
+        kwargs = handler.ingest_service.abort_run.await_args.kwargs
+        assert handler.ingest_service.abort_run.await_args.args[0] == "run-1"
+        assert kwargs["kind"] is FailureKind.IMAGE_PULL
+        assert kwargs["reason"] == "boom"
+        # The batch is neither completed nor re-driven.
+        assert not any(isinstance(e, HookBatchCompleted) for e in _emitted(handler))
+        handler.ingest_service.fail_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_abort_still_records_provenance(self) -> None:
+        """The failed hook's ERROR run is recorded before the abort — facts survive."""
+        execs = [
+            _passed_exec("hook_a"),
+            _failed_exec("hook_b", FailureKind.IMAGE_PULL, offset=10),
+        ]
+        handler = _make_handler(hook_names=("hook_a", "hook_b"), executions=execs)
+
+        await handler.handle(_make_event())
+
+        statuses = sorted(r.status for r in _recorded_runs(handler))
+        assert statuses == sorted([HookRunStatus.PASSED, HookRunStatus.ERROR])
+        handler.ingest_service.abort_run.assert_awaited_once()
+
+
+class TestTerminalRunGuard:
+    """Once a run is aborted, redelivered batch events must be dropped —
+    that is what actually stops the scheduled work (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_batch_for_failed_run_is_skipped(self) -> None:
+        handler = _make_handler(executions=[_passed_exec("pockets")])
+        handler.ingest_repo.get.return_value = IngestRun(
+            id=IngestRunId("run-1"),
+            convention_id="test-conv",
+            status=IngestStatus.FAILED,
+            batch_size=100,
+            started_at=_T0,
+        )
+
+        await handler.handle(_make_event())
+
+        handler.hook_service.run_hooks_for_batch.assert_not_called()
+        assert _emitted(handler) == []
+        handler.hook_registry.record_run.assert_not_called()

--- a/server/tests/unit/domain/ingest/test_run_hooks.py
+++ b/server/tests/unit/domain/ingest/test_run_hooks.py
@@ -297,3 +297,38 @@ class TestTerminalRunGuard:
         handler.hook_service.run_hooks_for_batch.assert_not_called()
         assert _emitted(handler) == []
         handler.hook_registry.record_run.assert_not_called()
+
+
+class TestDecisionPrecedence:
+    """The batch's fate is the most severe decision across its hooks (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_abort_dominates_retry_in_a_mixed_batch(self) -> None:
+        # hook_a wants a transient retry; hook_b hit an unpullable image.
+        execs = [
+            _failed_exec("hook_a", FailureKind.TIMEOUT),
+            _failed_exec("hook_b", FailureKind.IMAGE_PULL, offset=10),
+        ]
+        handler = _make_handler(hook_names=("hook_a", "hook_b"), executions=execs)
+
+        await handler.handle(_make_event())
+
+        # Abort wins: the run is hard-stopped, the batch is NOT re-driven or completed.
+        handler.ingest_service.abort_run.assert_awaited_once()
+        assert not any(isinstance(e, HookBatchCompleted) for e in _emitted(handler))
+
+
+class TestBatchExhaustionRecordsReason:
+    """A batch whose transient retries run out must leave a queryable reason (#152)."""
+
+    @pytest.mark.asyncio
+    async def test_on_exhausted_records_reason_and_batch(self) -> None:
+        handler = _make_handler(executions=[_passed_exec("pockets")])
+
+        await handler.on_exhausted(_make_event(batch_index=3))
+
+        call = handler.ingest_service.fail_batch.await_args
+        assert call.args[0] == "run-1"
+        assert "exhausted" in call.kwargs["reason"]
+        assert "3" in call.kwargs["reason"]
+        assert call.kwargs["kind"] is None

--- a/server/tests/unit/domain/ingest/test_run_ingester.py
+++ b/server/tests/unit/domain/ingest/test_run_ingester.py
@@ -1,0 +1,192 @@
+"""Tests for RunIngester — failure decisions are the policy's call (#152).
+
+The handler catches RuntimeFailure facts from the runner, asks the
+FailurePolicy what to do, and executes the verb: AbortRun → hard-stop the run;
+Retry → re-raise for the worker's budgeted redelivery; GiveUp → fail the
+ingestion with a queryable reason.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from osa.domain.ingest.event.events import IngesterBatchReady, NextBatchRequested
+from osa.domain.ingest.handler.run_ingester import RunIngester
+from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId, IngestStatus
+from osa.domain.shared.error import TransientError
+from osa.domain.shared.event import EventId
+from osa.domain.shared.failure import FailureKind, FailurePolicy, RuntimeFailure
+from osa.domain.shared.model.source import IngesterDefinition
+from osa.domain.shared.port.ingester_runner import IngesterOutput
+
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _make_event(ingest_run_id: str = "run-1") -> NextBatchRequested:
+    return NextBatchRequested(
+        id=EventId(uuid4()),
+        ingest_run_id=IngestRunId(ingest_run_id),
+        convention_id="test-conv",
+        batch_size=100,
+    )
+
+
+def _make_run(status: IngestStatus = IngestStatus.RUNNING) -> IngestRun:
+    return IngestRun(
+        id=IngestRunId("run-1"),
+        convention_id="test-conv",
+        status=status,
+        batch_size=100,
+        started_at=_T0,
+    )
+
+
+def _make_handler(
+    *,
+    run: IngestRun | None = None,
+    runner_failure: RuntimeFailure | None = None,
+) -> RunIngester:
+    ingest_repo = AsyncMock()
+    ingest_repo.get.return_value = run if run is not None else _make_run()
+
+    convention_service = AsyncMock()
+    conv = AsyncMock()
+    conv.id = "test-conv"
+    conv.ingester = IngesterDefinition(image="ghcr.io/x/ing:v1", digest="sha256:abc")
+    convention_service.get_convention.return_value = conv
+
+    ingester_runner = AsyncMock()
+    ingester_runner.has_capacity.return_value = True
+    if runner_failure is not None:
+        ingester_runner.run.side_effect = runner_failure
+    else:
+        ingester_runner.run.return_value = IngesterOutput(
+            records=[], session=None, files_dir=Path("/tmp/files")
+        )
+
+    ingest_storage = AsyncMock()
+    ingest_storage.read_session.return_value = None
+    ingest_storage.batch_work_dir.return_value = Path("/tmp/work")
+    ingest_storage.batch_files_dir.return_value = Path("/tmp/files")
+
+    return RunIngester(
+        ingest_repo=ingest_repo,
+        ingest_service=AsyncMock(),
+        convention_service=convention_service,
+        ingester_runner=ingester_runner,
+        outbox=AsyncMock(),
+        ingest_storage=ingest_storage,
+        failure_policy=FailurePolicy(),
+    )
+
+
+def _emitted(handler: RunIngester) -> list:
+    return [call[0][0] for call in handler.outbox.append.call_args_list]
+
+
+class TestAbortOnEnvironmentalFailure:
+    @pytest.mark.asyncio
+    async def test_image_pull_failure_aborts_run(self) -> None:
+        failure = RuntimeFailure(FailureKind.IMAGE_PULL, "Image pull failed: 401 Unauthorized")
+        handler = _make_handler(runner_failure=failure)
+
+        await handler.handle(_make_event())
+
+        kwargs = handler.ingest_service.abort_run.await_args.kwargs
+        assert handler.ingest_service.abort_run.await_args.args[0] == "run-1"
+        assert kwargs["reason"] == "Image pull failed: 401 Unauthorized"
+        assert kwargs["kind"] is FailureKind.IMAGE_PULL
+        # No batch produced, no continuation scheduled, no per-batch failure.
+        assert _emitted(handler) == []
+        handler.ingest_service.fail_ingestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rbac_failure_aborts_run(self) -> None:
+        failure = RuntimeFailure(FailureKind.RBAC, "K8s RBAC permission denied")
+        handler = _make_handler(runner_failure=failure)
+
+        await handler.handle(_make_event())
+
+        assert handler.ingest_service.abort_run.await_args.kwargs["kind"] is FailureKind.RBAC
+
+
+class TestRetryableFailuresReachTheWorker:
+    @pytest.mark.asyncio
+    async def test_timeout_re_raises_for_budgeted_redelivery(self) -> None:
+        failure = RuntimeFailure(FailureKind.TIMEOUT, "Ingester timed out")
+        handler = _make_handler(runner_failure=failure)
+
+        with pytest.raises(TransientError):
+            await handler.handle(_make_event())
+
+        handler.ingest_service.abort_run.assert_not_called()
+        handler.ingest_service.fail_ingestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upstream_exit_re_raises_for_budgeted_redelivery(self) -> None:
+        failure = RuntimeFailure(FailureKind.UPSTREAM, "Source exited with code 3", exit_code=3)
+        handler = _make_handler(runner_failure=failure)
+
+        with pytest.raises(TransientError):
+            await handler.handle(_make_event())
+
+
+class TestGiveUpFailsIngestionWithReason:
+    @pytest.mark.asyncio
+    async def test_unknown_failure_fails_ingestion(self) -> None:
+        failure = RuntimeFailure(FailureKind.UNKNOWN, "Source failed: PodFailurePolicy")
+        handler = _make_handler(runner_failure=failure)
+
+        await handler.handle(_make_event())
+
+        kwargs = handler.ingest_service.fail_ingestion.await_args.kwargs
+        assert handler.ingest_service.fail_ingestion.await_args.args[0] == "run-1"
+        assert kwargs["reason"] == "Source failed: PodFailurePolicy"
+        assert kwargs["kind"] is FailureKind.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_oom_fails_ingestion(self) -> None:
+        """Ingester Jobs have no memory-bump loop — an OOM gives up with the facts."""
+        failure = RuntimeFailure(FailureKind.OOM, "Source killed by OOM")
+        handler = _make_handler(runner_failure=failure)
+
+        await handler.handle(_make_event())
+
+        kwargs = handler.ingest_service.fail_ingestion.await_args.kwargs
+        assert kwargs["kind"] is FailureKind.OOM
+
+
+class TestExhaustedRetriesFailIngestion:
+    @pytest.mark.asyncio
+    async def test_on_exhausted_records_reason(self) -> None:
+        handler = _make_handler()
+
+        await handler.on_exhausted(_make_event())
+
+        kwargs = handler.ingest_service.fail_ingestion.await_args.kwargs
+        assert "exhausted" in kwargs["reason"]
+
+
+class TestTerminalRunGuard:
+    """Redelivered NextBatchRequested for an aborted run must be dropped."""
+
+    @pytest.mark.asyncio
+    async def test_failed_run_skips_ingester(self) -> None:
+        handler = _make_handler(run=_make_run(status=IngestStatus.FAILED))
+
+        await handler.handle(_make_event())
+
+        handler.ingester_runner.run.assert_not_called()
+        assert _emitted(handler) == []
+
+    @pytest.mark.asyncio
+    async def test_healthy_run_still_ingests(self) -> None:
+        handler = _make_handler()
+
+        await handler.handle(_make_event())
+
+        handler.ingester_runner.run.assert_awaited_once()
+        assert any(isinstance(e, IngesterBatchReady) for e in _emitted(handler))

--- a/server/tests/unit/domain/shared/test_error_types.py
+++ b/server/tests/unit/domain/shared/test_error_types.py
@@ -1,26 +1,15 @@
-"""Tests for runner-specific error types."""
+"""Tests for worker delivery-control error types.
+
+Container runners no longer raise these — they report RuntimeFailure facts
+(see test_failure_policy.py). Transient/Permanent remain the worker's generic
+retry / fail-now verbs for event handlers.
+"""
 
 from osa.domain.shared.error import (
     InfrastructureError,
-    OOMError,
     PermanentError,
     TransientError,
 )
-
-
-class TestOOMError:
-    def test_is_infrastructure_error(self):
-        err = OOMError("Hook killed by OOM")
-        assert isinstance(err, InfrastructureError)
-
-    def test_is_permanent_error(self):
-        err = OOMError("Hook killed by OOM")
-        assert isinstance(err, PermanentError)
-
-    def test_message_and_code(self):
-        err = OOMError("Hook killed by OOM")
-        assert err.message == "Hook killed by OOM"
-        assert err.code == "OOMError"
 
 
 class TestTransientError:

--- a/server/tests/unit/domain/shared/test_failure_policy.py
+++ b/server/tests/unit/domain/shared/test_failure_policy.py
@@ -1,0 +1,137 @@
+"""FailurePolicy decision matrix — facts → policy → action (#152).
+
+The policy is the ONE place runtime-failure disposition lives. Runners report
+facts (RuntimeFailure with a cause FailureKind); the policy maps
+(failure, prior attempts) → an action verb; executors carry it out.
+
+Budget split (the crux from #152): the outbox/worker keeps the generic
+transient redelivery budget (it owns delivery.retry_count), so the policy's
+Retry is unconditional for retryable kinds. The policy owns the one budget the
+outbox can't see: OOM memory bumps.
+"""
+
+import pytest
+
+from osa.domain.shared.failure import (
+    AbortRun,
+    FailureKind,
+    FailurePolicy,
+    GiveUp,
+    PriorAttempts,
+    Retry,
+    RetryWithMoreMemory,
+    RuntimeFailure,
+)
+
+FRESH = PriorAttempts(memory_bumps=0)
+
+
+def _policy(max_memory_bumps: int = 3) -> FailurePolicy:
+    return FailurePolicy(max_memory_bumps=max_memory_bumps)
+
+
+class TestEnvironmentalFailuresAbortTheRun:
+    """A failure that recurs identically for every batch dooms the whole run."""
+
+    @pytest.mark.parametrize("kind", [FailureKind.IMAGE_PULL, FailureKind.RBAC, FailureKind.CONFIG])
+    def test_aborts_run(self, kind: FailureKind) -> None:
+        failure = RuntimeFailure(kind, "Image pull failed: 401 Unauthorized")
+
+        decision = _policy().decide(failure, FRESH)
+
+        assert decision == AbortRun(reason="Image pull failed: 401 Unauthorized", kind=kind)
+
+    def test_aborts_even_with_prior_attempts(self) -> None:
+        failure = RuntimeFailure(FailureKind.RBAC, "K8s RBAC permission denied")
+
+        decision = _policy().decide(failure, PriorAttempts(memory_bumps=2))
+
+        assert isinstance(decision, AbortRun)
+
+
+class TestOomIsRemediatedThenGivenUp:
+    """OOM retries with more memory until the bump budget is spent — no
+    'permanent error secretly intercepted' any more."""
+
+    def test_first_oom_gets_a_memory_bump(self) -> None:
+        failure = RuntimeFailure(FailureKind.OOM, "Hook killed by OOM (limit: 512m)")
+
+        decision = _policy(max_memory_bumps=3).decide(failure, FRESH)
+
+        assert decision == RetryWithMoreMemory()
+
+    def test_bump_below_budget_still_retries(self) -> None:
+        failure = RuntimeFailure(FailureKind.OOM, "Hook killed by OOM (limit: 2g)")
+
+        decision = _policy(max_memory_bumps=3).decide(failure, PriorAttempts(memory_bumps=2))
+
+        assert decision == RetryWithMoreMemory()
+
+    def test_budget_exhausted_gives_up(self) -> None:
+        failure = RuntimeFailure(FailureKind.OOM, "Hook killed by OOM (limit: 4g)")
+
+        decision = _policy(max_memory_bumps=3).decide(failure, PriorAttempts(memory_bumps=3))
+
+        assert decision == GiveUp(
+            reason="out of memory headroom after 3 bumps", kind=FailureKind.OOM
+        )
+
+
+class TestRetryableKindsDeferToTheOutboxBudget:
+    """Timeout / upstream / runtime hiccups retry; exhaustion is enforced by
+    the worker's delivery budget, not duplicated here."""
+
+    @pytest.mark.parametrize(
+        "kind", [FailureKind.TIMEOUT, FailureKind.UPSTREAM, FailureKind.RUNTIME]
+    )
+    def test_retries(self, kind: FailureKind) -> None:
+        failure = RuntimeFailure(kind, "watch timeout waiting for Job")
+
+        decision = _policy().decide(failure, FRESH)
+
+        assert decision == Retry()
+
+
+class TestDeterministicExitsAreNotBlindlyRetried:
+    def test_hook_exit_gives_up_with_exit_code(self) -> None:
+        failure = RuntimeFailure(FailureKind.HOOK_EXIT, "Hook exited with code 2", exit_code=2)
+
+        decision = _policy().decide(failure, FRESH)
+
+        assert decision == GiveUp(reason="hook exited with code 2", kind=FailureKind.HOOK_EXIT)
+
+    def test_unknown_gives_up_with_detail(self) -> None:
+        failure = RuntimeFailure(FailureKind.UNKNOWN, "Hook failed: PodFailurePolicy")
+
+        decision = _policy().decide(failure, FRESH)
+
+        assert decision == GiveUp(reason="Hook failed: PodFailurePolicy", kind=FailureKind.UNKNOWN)
+
+
+class TestRuntimeFailureFacts:
+    """RuntimeFailure is an observation: cause + diagnostics, no disposition."""
+
+    def test_carries_typed_fields(self) -> None:
+        failure = RuntimeFailure(
+            FailureKind.HOOK_EXIT,
+            "Hook exited with code 137",
+            exit_code=137,
+            container_logs="Traceback ...",
+        )
+
+        assert failure.kind is FailureKind.HOOK_EXIT
+        assert failure.detail == "Hook exited with code 137"
+        assert failure.exit_code == 137
+        assert failure.container_logs == "Traceback ..."
+        assert failure.oom_retries == 0
+        assert str(failure) == "Hook exited with code 137"
+
+    def test_is_not_an_http_mapped_infrastructure_error(self) -> None:
+        # Runtime failures drive worker policy, not HTTP responses — they must
+        # not inherit the 503-mapped InfrastructureError semantics.
+        from osa.domain.shared.error import InfrastructureError, OSAError
+
+        failure = RuntimeFailure(FailureKind.RUNTIME, "docker hiccup")
+
+        assert isinstance(failure, OSAError)
+        assert not isinstance(failure, InfrastructureError)

--- a/server/tests/unit/domain/shared/test_failure_policy.py
+++ b/server/tests/unit/domain/shared/test_failure_policy.py
@@ -21,6 +21,7 @@ from osa.domain.shared.failure import (
     Retry,
     RetryWithMoreMemory,
     RuntimeFailure,
+    most_severe,
 )
 
 FRESH = PriorAttempts(memory_bumps=0)
@@ -135,3 +136,38 @@ class TestRuntimeFailureFacts:
 
         assert isinstance(failure, OSAError)
         assert not isinstance(failure, InfrastructureError)
+
+
+class TestMostSevere:
+    """most_severe reduces one batch's per-hook decisions to the verb that wins.
+
+    Precedence follows blast radius: AbortRun (kills the run) dominates Retry
+    (re-drive the batch) dominates the terminal per-hook verbs. This is what lets
+    a batch handler pick a single action without a chain of isinstance checks.
+    """
+
+    _GIVE = GiveUp(reason="hook exited 2", kind=FailureKind.HOOK_EXIT)
+    _ABORT = AbortRun(reason="bad image", kind=FailureKind.IMAGE_PULL)
+
+    def test_empty_batch_yields_none(self) -> None:
+        assert most_severe([]) is None
+
+    def test_single_decision_passes_through(self) -> None:
+        assert most_severe([self._GIVE]) is self._GIVE
+
+    def test_retry_dominates_give_up(self) -> None:
+        assert most_severe([self._GIVE, Retry()]) == Retry()
+
+    def test_retry_with_more_memory_ranks_above_give_up(self) -> None:
+        assert most_severe([self._GIVE, RetryWithMoreMemory()]) == RetryWithMoreMemory()
+
+    def test_abort_dominates_everything(self) -> None:
+        assert most_severe([Retry(), self._GIVE, self._ABORT]) == self._ABORT
+
+    def test_order_independent(self) -> None:
+        assert most_severe([self._ABORT, Retry(), self._GIVE]) == self._ABORT
+
+    def test_ties_keep_the_first_seen(self) -> None:
+        first = AbortRun(reason="first", kind=FailureKind.RBAC)
+        second = AbortRun(reason="second", kind=FailureKind.IMAGE_PULL)
+        assert most_severe([first, second]) is first

--- a/server/tests/unit/domain/validation/test_hook_result.py
+++ b/server/tests/unit/domain/validation/test_hook_result.py
@@ -115,3 +115,54 @@ def test_hook_result_serialization_roundtrip():
     data = result.model_dump()
     restored = HookResult.model_validate(data)
     assert restored == result
+
+
+def _errored_execution(**overrides):
+    """A failed HookExecution built directly (no runner scaffolding)."""
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from osa.domain.shared.failure import FailureKind
+    from osa.domain.validation.model.hook_release import HookReleaseId
+    from osa.domain.validation.model.hook_result import HookExecution
+
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
+    fields = {
+        "hook_name": "detect_pockets",
+        "release_id": HookReleaseId(uuid4()),
+        "status": None,
+        "started_at": t0,
+        "finished_at": t0,
+        "duration_s": 2.0,
+        "oom_retries": 0,
+        "failure": FailureKind.HOOK_EXIT,
+        "error_message": "Hook exited with code 2",
+    }
+    fields.update(overrides)
+    return HookExecution(**fields)
+
+
+def test_hook_execution_as_failure_rehydrates_facts():
+    """as_failure() is the inverse of failed(): kind, detail, and bump count survive."""
+    from osa.domain.shared.failure import FailureKind
+
+    execution = _errored_execution(
+        failure=FailureKind.OOM, error_message="OOM after 3 retries", oom_retries=3
+    )
+
+    failure = execution.as_failure()
+
+    assert failure.kind is FailureKind.OOM
+    assert failure.detail == "OOM after 3 retries"
+    assert failure.oom_retries == 3
+
+
+def test_hook_execution_as_failure_rejects_a_non_errored_execution():
+    from osa.domain.validation.model.hook_result import HookStatus
+
+    passed = _errored_execution(status=HookStatus.PASSED, failure=None, error_message=None)
+
+    import pytest
+
+    with pytest.raises(ValueError, match="did not error"):
+        passed.as_failure()

--- a/server/tests/unit/domain/validation/test_hook_service.py
+++ b/server/tests/unit/domain/validation/test_hook_service.py
@@ -21,7 +21,7 @@ from osa.domain.validation.model.batch_outcome import (
     OutcomeStatus,
 )
 from osa.domain.validation.model.hook_input import HookRecord
-from osa.domain.shared.error import OOMError
+from osa.domain.shared.failure import FailureKind, FailurePolicy, RuntimeFailure
 from osa.domain.validation.model.hook_release import HookRelease, HookReleaseId
 from osa.domain.validation.model.hook_result import HookResult, HookStatus
 from osa.domain.validation.port.hook_runner import HookInputs
@@ -65,8 +65,8 @@ def _passed_result(hook_name: str = "detect_pockets", duration: float = 5.0) -> 
     return HookResult(hook_name=hook_name, status=HookStatus.PASSED, duration_seconds=duration)
 
 
-def _oom_error() -> OOMError:
-    return OOMError("Hook killed by OOM")
+def _oom_failure() -> RuntimeFailure:
+    return RuntimeFailure(FailureKind.OOM, "Hook killed by OOM")
 
 
 class FakeHookStorage:
@@ -132,7 +132,9 @@ class TestHookServiceNoOOM:
             + "\n"
         )
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -174,7 +176,9 @@ class TestHookServiceBatchTimestamps:
 
         runner = AsyncMock()
         runner.run.side_effect = mock_run
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=FailurePolicy()
+        )
 
         executions = await service.run_hooks_for_batch(
             [(hook1, rel1), (hook2, rel2)],
@@ -185,7 +189,7 @@ class TestHookServiceBatchTimestamps:
         assert [e.hook_name.root for e in executions] == ["hook_one", "hook_two"]
         for e in executions:
             assert e.started_at <= e.finished_at
-            assert e.is_terminal
+            assert e.failure is None
         # Sequential, non-overlapping per-hook windows — not one shared batch span.
         assert executions[1].started_at >= executions[0].finished_at
 
@@ -201,8 +205,7 @@ class TestHookServiceBatchErrorsAsValues:
     async def test_continue_on_error_surfaces_passed_and_failed(self, tmp_path: Path):
         import json
 
-        from osa.domain.shared.error import PermanentError
-        from osa.domain.validation.model.hook_result import FailureKind, HookStatus
+        from osa.domain.validation.model.hook_result import HookStatus
         from osa.domain.validation.service.hook import HookService
 
         hook1, hook2 = _make_hook("hook_one"), _make_hook("hook_two")
@@ -214,7 +217,7 @@ class TestHookServiceBatchErrorsAsValues:
 
         async def mock_run(h, rel, inputs, wd):
             if h.name.root == "hook_two":
-                raise PermanentError("image pull failed")
+                raise RuntimeFailure(FailureKind.IMAGE_PULL, "image pull failed")
             (wd / "output" / "features.jsonl").write_text(
                 json.dumps({"id": records[0].id, "features": [{"score": 0.9}]}) + "\n"
             )
@@ -222,7 +225,9 @@ class TestHookServiceBatchErrorsAsValues:
 
         runner = AsyncMock()
         runner.run.side_effect = mock_run
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=FailurePolicy()
+        )
 
         execs = await service.run_hooks_for_batch(
             [(hook1, rel1), (hook2, rel2)], _inputs(records), {hook1.name: wd1, hook2.name: wd2}
@@ -231,17 +236,14 @@ class TestHookServiceBatchErrorsAsValues:
         assert len(execs) == 2  # hook 2's failure did NOT discard hook 1
         assert execs[0].hook_name.root == "hook_one"
         assert execs[0].status == HookStatus.PASSED and execs[0].failure is None
-        assert execs[0].is_terminal
         assert execs[1].hook_name.root == "hook_two"
-        assert execs[1].status is None and execs[1].failure == FailureKind.PERMANENT
-        assert execs[1].is_terminal
+        # The execution carries the observed cause — disposition is the policy's call.
+        assert execs[1].status is None and execs[1].failure == FailureKind.IMAGE_PULL
         # Each keeps its own window.
         assert execs[1].started_at >= execs[0].finished_at
 
     @pytest.mark.asyncio
-    async def test_transient_failure_is_not_terminal(self, tmp_path: Path):
-        from osa.domain.shared.error import TransientError
-        from osa.domain.validation.model.hook_result import FailureKind
+    async def test_failed_execution_preserves_cause_kind(self, tmp_path: Path):
         from osa.domain.validation.service.hook import HookService
 
         hook, rel = _make_hook(), _make_release()
@@ -250,18 +252,19 @@ class TestHookServiceBatchErrorsAsValues:
         (wd / "output").mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = TransientError("registry timeout")
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        runner.run.side_effect = RuntimeFailure(FailureKind.TIMEOUT, "registry timeout")
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=FailurePolicy()
+        )
 
         execs = await service.run_hooks_for_batch([(hook, rel)], _inputs(records), {hook.name: wd})
 
-        assert execs[0].failure == FailureKind.TRANSIENT
-        assert execs[0].is_terminal is False
+        assert execs[0].failure == FailureKind.TIMEOUT
+        assert execs[0].error_message == "registry timeout"
 
     @pytest.mark.asyncio
-    async def test_oom_exhaustion_is_terminal_with_retry_count(self, tmp_path: Path):
-        from osa.domain.validation.model.hook_result import FailureKind
-        from osa.domain.validation.service.hook import HookService, MAX_OOM_RETRIES
+    async def test_oom_exhaustion_surfaces_with_retry_count(self, tmp_path: Path):
+        from osa.domain.validation.service.hook import HookService
 
         hook, rel = _make_hook(), _make_release()
         records = _make_records(1)
@@ -269,19 +272,20 @@ class TestHookServiceBatchErrorsAsValues:
         (wd / "output").mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = _oom_error()  # OOM on every attempt → exhaustion
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        runner.run.side_effect = _oom_failure()  # OOM on every attempt → exhaustion
+        policy = FailurePolicy(max_memory_bumps=3)
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=policy
+        )
 
         execs = await service.run_hooks_for_batch([(hook, rel)], _inputs(records), {hook.name: wd})
 
-        assert execs[0].failure == FailureKind.OOM_EXHAUSTED
-        assert execs[0].is_terminal
-        assert execs[0].oom_retries == MAX_OOM_RETRIES
+        assert execs[0].failure == FailureKind.OOM
+        assert execs[0].oom_retries == 3
 
     @pytest.mark.asyncio
     async def test_failed_execution_captures_container_logs(self, tmp_path: Path):
         """A runner failure's container_logs surface on the execution's log_text (#145/#147)."""
-        from osa.domain.shared.error import PermanentError
         from osa.domain.validation.service.hook import HookService
 
         hook, rel = _make_hook(), _make_release()
@@ -290,8 +294,12 @@ class TestHookServiceBatchErrorsAsValues:
         (wd / "output").mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = PermanentError("exit 1", container_logs="stderr: kaboom")
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        runner.run.side_effect = RuntimeFailure(
+            FailureKind.HOOK_EXIT, "exit 1", exit_code=1, container_logs="stderr: kaboom"
+        )
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=FailurePolicy()
+        )
 
         execs = await service.run_hooks_for_batch([(hook, rel)], _inputs(records), {hook.name: wd})
 
@@ -308,8 +316,12 @@ class TestHookServiceBatchErrorsAsValues:
         (wd / "output").mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = OOMError("Hook killed by OOM", container_logs="oom tail")
-        service = HookService(hook_runner=runner, hook_storage=FakeHookStorage())
+        runner.run.side_effect = RuntimeFailure(
+            FailureKind.OOM, "Hook killed by OOM", container_logs="oom tail"
+        )
+        service = HookService(
+            hook_runner=runner, hook_storage=FakeHookStorage(), failure_policy=FailurePolicy()
+        )
 
         execs = await service.run_hooks_for_batch([(hook, rel)], _inputs(records), {hook.name: wd})
 
@@ -344,7 +356,7 @@ class TestHookServiceOOMRetry:
                 features_file.write_text(
                     json.dumps({"id": records[0].id, "features": [{"score": 0.5}]}) + "\n"
                 )
-                raise _oom_error()
+                raise _oom_failure()
             else:
                 # Second call: succeed with remaining
                 features_file = output_dir / "features.jsonl"
@@ -357,7 +369,9 @@ class TestHookServiceOOMRetry:
         runner.run.side_effect = mock_run
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -388,7 +402,7 @@ class TestHookServiceOOMRetry:
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
-                raise _oom_error()
+                raise _oom_failure()
             features_file = output_dir / "features.jsonl"
             features_file.write_text(
                 json.dumps({"id": records[0].id, "features": [{"score": 0.8}]}) + "\n"
@@ -399,7 +413,9 @@ class TestHookServiceOOMRetry:
         runner.run.side_effect = mock_run
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -425,14 +441,19 @@ class TestHookServiceOOMExhaustion:
         output_dir.mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = _oom_error()
+        runner.run.side_effect = _oom_failure()
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
-        with pytest.raises(OOMError):
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
+        with pytest.raises(RuntimeFailure) as exc_info:
             await service.run_hook(hook, release, _inputs(records), work_dir)
 
-        # Should have retried MAX_OOM_RETRIES times
+        # The give-up re-raise carries the facts: OOM cause + real bump count.
+        assert exc_info.value.kind is FailureKind.OOM
+        assert exc_info.value.oom_retries == 3
+        # Should have retried max_memory_bumps times
         assert runner.run.call_count == 4  # 1 initial + 3 retries
 
         # Check outcomes written with error
@@ -448,7 +469,6 @@ class TestHookServiceNonOOMFailure:
 
     @pytest.mark.asyncio
     async def test_non_oom_failure_no_retry(self, tmp_path: Path):
-        from osa.domain.shared.error import PermanentError
         from osa.domain.validation.service.hook import HookService
 
         hook = _make_hook()
@@ -459,13 +479,18 @@ class TestHookServiceNonOOMFailure:
         (work_dir / "output").mkdir(parents=True)
 
         runner = AsyncMock()
-        runner.run.side_effect = PermanentError("Hook exited with code 1")
+        runner.run.side_effect = RuntimeFailure(
+            FailureKind.HOOK_EXIT, "Hook exited with code 1", exit_code=1
+        )
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
-        with pytest.raises(PermanentError):
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
+        with pytest.raises(RuntimeFailure) as exc_info:
             await service.run_hook(hook, release, _inputs(records), work_dir)
 
+        assert exc_info.value.kind is FailureKind.HOOK_EXIT
         runner.run.assert_called_once()
 
 
@@ -496,7 +521,9 @@ class TestHookServiceFinalize:
         runner.run.return_value = _passed_result()
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert str(work_dir) in storage.written_outcomes
@@ -522,7 +549,9 @@ class TestHookServiceEmptyRecords:
         runner = AsyncMock()
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs([]), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -567,18 +596,20 @@ class TestHookServiceMultiHook:
             if h.name.root == "hook_one":
                 return _passed_result(hook_name="hook_one")
             else:
-                raise _oom_error()
+                raise _oom_failure()
 
         runner.run.side_effect = side_effect
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
 
         # Run hook 1 — should pass
         r1 = await service.run_hook(hook1, release1, _inputs(records), work_dir1)
         assert r1.status == HookStatus.PASSED
 
         # Run hook 2 — should OOM and exhaust retries, then raise
-        with pytest.raises(OOMError):
+        with pytest.raises(RuntimeFailure):
             await service.run_hook(hook2, release2, _inputs(records), work_dir2)
 
         # Hook 1 was called once, hook 2 was called 4 times (1 + 3 retries)
@@ -634,7 +665,9 @@ class TestHookServiceCheckpointRecovery:
 
         runner.run.side_effect = mock_run
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -670,7 +703,9 @@ class TestHookServiceCheckpointAllComplete:
         runner = AsyncMock()
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED
@@ -714,7 +749,9 @@ class TestHookServiceSorting:
         runner.run.side_effect = mock_run
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert captured_order == ["small", "medium", "large"]
@@ -753,7 +790,9 @@ class TestHookServiceSorting:
         runner.run.side_effect = mock_run
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert captured_order == ["a", "b", "c"]
@@ -794,7 +833,9 @@ class TestHookServiceCorruptedCheckpoint:
         runner.run.side_effect = mock_run
         storage = FakeHookStorage()
 
-        service = HookService(hook_runner=runner, hook_storage=storage)
+        service = HookService(
+            hook_runner=runner, hook_storage=storage, failure_policy=FailurePolicy()
+        )
         result = await service.run_hook(hook, release, _inputs(records), work_dir)
 
         assert result.status == HookStatus.PASSED

--- a/server/tests/unit/domain/validation/test_validation_service.py
+++ b/server/tests/unit/domain/validation/test_validation_service.py
@@ -15,7 +15,7 @@ from osa.domain.shared.model.hook import (
 )
 from osa.domain.shared.model.srn import DepositionSRN, Domain
 from osa.domain.validation.model import RunStatus
-from osa.domain.shared.error import OOMError, PermanentError
+from osa.domain.shared.failure import FailureKind, FailurePolicy, RuntimeFailure
 from osa.domain.validation.model.hook import Hook
 from osa.domain.validation.model.hook_release import HookRelease, HookReleaseId
 from osa.domain.validation.model.hook_result import HookResult, HookStatus
@@ -99,6 +99,7 @@ def _make_service(
         hook_runner=hook_runner or AsyncMock(),
         hook_storage=hs,
         hook_registry=hook_registry or _make_registry(["pocket_detect"]),
+        failure_policy=FailurePolicy(),
         node_domain=Domain("localhost"),
     )
 
@@ -171,8 +172,11 @@ class TestValidationServiceRunHooks:
     @pytest.mark.asyncio
     async def test_hook_failed_halts_pipeline(self):
         hook_runner = AsyncMock()
-        hook_runner.run.side_effect = PermanentError(
-            "Hook exited with code 1", container_logs="traceback: boom"
+        hook_runner.run.side_effect = RuntimeFailure(
+            FailureKind.HOOK_EXIT,
+            "Hook exited with code 1",
+            exit_code=1,
+            container_logs="traceback: boom",
         )
         registry = _make_registry(["pocket_detect"])
         service = _make_service(hook_runner=hook_runner, hook_registry=registry)
@@ -248,10 +252,8 @@ class TestValidationServiceRunHooks:
     @pytest.mark.asyncio
     async def test_validation_service_halts_on_oom(self):
         """REGRESSION: OOM with exhausted retries should halt pipeline as FAILED."""
-        from osa.domain.validation.service.hook import MAX_OOM_RETRIES
-
         hook_runner = AsyncMock()
-        hook_runner.run.side_effect = OOMError("Hook killed by OOM")
+        hook_runner.run.side_effect = RuntimeFailure(FailureKind.OOM, "Hook killed by OOM")
         registry = _make_registry(["pocket_detect"])
         service = _make_service(hook_runner=hook_runner, hook_registry=registry)
         run = await service.create_run(inputs=_make_inputs())
@@ -265,10 +267,11 @@ class TestValidationServiceRunHooks:
 
         assert run.status == RunStatus.FAILED
         # The real OOM-retry count must reach provenance — not a hardcoded 0.
-        # run_hook re-raises OOMError(oom_retries=...) after exhausting retries.
+        # run_hook re-raises the OOM failure with oom_retries after exhausting
+        # the policy's memory-bump budget (default 3).
         recorded_run = registry.record_run.await_args.args[0]
         assert recorded_run.status == HookRunStatus.ERROR
-        assert recorded_run.oom_retries == MAX_OOM_RETRIES
+        assert recorded_run.oom_retries == 3
 
     @pytest.mark.asyncio
     async def test_validation_service_retries_on_oom(self):
@@ -279,7 +282,7 @@ class TestValidationServiceRunHooks:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise OOMError("Hook killed by OOM")
+                raise RuntimeFailure(FailureKind.OOM, "Hook killed by OOM")
             return HookResult(
                 hook_name=hook.name.root,
                 status=HookStatus.PASSED,

--- a/server/tests/unit/domain/validation/test_validation_service_decoupled.py
+++ b/server/tests/unit/domain/validation/test_validation_service_decoupled.py
@@ -19,6 +19,7 @@ from osa.domain.shared.model.hook import (
     OciConfig,
     TableFeatureSpec,
 )
+from osa.domain.shared.failure import FailurePolicy
 from osa.domain.shared.model.srn import ConventionSlug, DepositionSRN, Domain
 from osa.domain.validation.model import RunStatus
 from osa.domain.validation.model.hook import Hook
@@ -111,6 +112,7 @@ class TestDecoupledValidationService:
             hook_runner=hook_runner,
             hook_storage=hook_storage,
             hook_registry=_make_registry("pocketeer"),
+            failure_policy=FailurePolicy(),
             node_domain=Domain("localhost"),
         )
 

--- a/server/tests/unit/infrastructure/k8s/test_classify_api_error.py
+++ b/server/tests/unit/infrastructure/k8s/test_classify_api_error.py
@@ -1,6 +1,6 @@
-"""Tests for K8s API error classification."""
+"""Tests for K8s API error classification — facts only, no disposition (#152)."""
 
-from osa.domain.shared.error import PermanentError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.infrastructure.k8s.errors import classify_api_error
 
 
@@ -14,33 +14,36 @@ class _FakeApiException(Exception):
 
 
 class TestClassifyApiError:
-    def test_403_returns_permanent_runner_error(self):
+    def test_403_is_an_rbac_failure(self):
         exc = _FakeApiException(403, "Forbidden")
         result = classify_api_error(exc)
-        assert isinstance(result, PermanentError)
-        assert "RBAC" in result.message or "permission" in result.message.lower()
+        assert isinstance(result, RuntimeFailure)
+        assert result.kind is FailureKind.RBAC
+        assert "RBAC" in result.detail or "permission" in result.detail.lower()
 
-    def test_404_returns_permanent_runner_error(self):
+    def test_404_is_a_config_failure(self):
         exc = _FakeApiException(404, "Not Found")
         result = classify_api_error(exc)
-        assert isinstance(result, PermanentError)
+        assert isinstance(result, RuntimeFailure)
+        assert result.kind is FailureKind.CONFIG
 
-    def test_500_returns_transient_resource_error(self):
+    def test_500_is_a_runtime_failure(self):
         exc = _FakeApiException(500, "Internal Server Error")
         result = classify_api_error(exc)
-        assert isinstance(result, TransientError)
+        assert isinstance(result, RuntimeFailure)
+        assert result.kind is FailureKind.RUNTIME
 
-    def test_503_returns_transient_resource_error(self):
+    def test_503_is_a_runtime_failure(self):
         exc = _FakeApiException(503, "Service Unavailable")
         result = classify_api_error(exc)
-        assert isinstance(result, TransientError)
+        assert result.kind is FailureKind.RUNTIME
 
-    def test_409_returns_transient_resource_error(self):
+    def test_409_is_a_runtime_failure(self):
         exc = _FakeApiException(409, "Conflict")
         result = classify_api_error(exc)
-        assert isinstance(result, TransientError)
+        assert result.kind is FailureKind.RUNTIME
 
-    def test_unknown_status_returns_transient_resource_error(self):
+    def test_unknown_status_is_a_runtime_failure(self):
         exc = _FakeApiException(429, "Too Many Requests")
         result = classify_api_error(exc)
-        assert isinstance(result, TransientError)
+        assert result.kind is FailureKind.RUNTIME

--- a/server/tests/unit/infrastructure/k8s/test_k8s_hook_runner.py
+++ b/server/tests/unit/infrastructure/k8s/test_k8s_hook_runner.py
@@ -8,11 +8,7 @@ from uuid import uuid4
 import pytest
 
 from osa.config import K8sConfig
-from osa.domain.shared.error import (
-    OOMError,
-    PermanentError,
-    TransientError,
-)
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.hook import (
     ColumnDef,
     HookIdentity,
@@ -411,10 +407,11 @@ class TestSchedulingWatch:
         pod_list.items = [pod]
         core_api.list_namespaced_pod.return_value = pod_list
 
-        with pytest.raises(TransientError, match="scheduling"):
+        with pytest.raises(RuntimeFailure, match="scheduling") as exc_info:
             await runner._wait_for_scheduling(
                 "test-job", "osa", timeout_seconds=0.1, poll_interval=0.05
             )
+        assert exc_info.value.kind is FailureKind.TIMEOUT
 
     @pytest.mark.asyncio
     async def test_image_pull_backoff_fails_fast(self):
@@ -432,8 +429,9 @@ class TestSchedulingWatch:
         pod_list.items = [pod]
         core_api.list_namespaced_pod.return_value = pod_list
 
-        with pytest.raises(PermanentError, match="[Ii]mage pull"):
+        with pytest.raises(RuntimeFailure, match="[Ii]mage pull") as exc_info:
             await runner._wait_for_scheduling("test-job", "osa")
+        assert exc_info.value.kind is FailureKind.IMAGE_PULL
 
     @pytest.mark.asyncio
     async def test_err_image_pull_fails_fast(self):
@@ -451,8 +449,9 @@ class TestSchedulingWatch:
         pod_list.items = [pod]
         core_api.list_namespaced_pod.return_value = pod_list
 
-        with pytest.raises(PermanentError, match="[Ii]mage pull"):
+        with pytest.raises(RuntimeFailure, match="[Ii]mage pull") as exc_info:
             await runner._wait_for_scheduling("test-job", "osa")
+        assert exc_info.value.kind is FailureKind.IMAGE_PULL
 
     @pytest.mark.asyncio
     async def test_pod_evicted(self):
@@ -468,8 +467,9 @@ class TestSchedulingWatch:
         pod_list.items = [pod]
         core_api.list_namespaced_pod.return_value = pod_list
 
-        with pytest.raises(TransientError, match="[Ee]vict"):
+        with pytest.raises(RuntimeFailure, match="[Ee]vict") as exc_info:
             await runner._wait_for_scheduling("test-job", "osa")
+        assert exc_info.value.kind is FailureKind.RUNTIME
 
 
 # ---------------------------------------------------------------------------
@@ -571,13 +571,14 @@ class TestExecutionAndCleanup:
         work_dir.mkdir(parents=True)
         inputs = HookInputs(records=[HookRecord(id="test", metadata={})], run_id=_RUN_ID)
 
-        with pytest.raises(TransientError, match="[Tt]imed out|[Dd]eadline"):
+        with pytest.raises(RuntimeFailure, match="[Tt]imed out|[Dd]eadline") as exc_info:
             await runner._run_job(
                 hook,
                 release,
                 inputs,
                 work_dir,
             )
+        assert exc_info.value.kind is FailureKind.TIMEOUT
         batch_api.delete_namespaced_job.assert_called_once()
 
     @pytest.mark.asyncio
@@ -633,13 +634,14 @@ class TestExecutionAndCleanup:
         work_dir.mkdir(parents=True)
         inputs = HookInputs(records=[HookRecord(id="test", metadata={})], run_id=_RUN_ID)
 
-        with pytest.raises(OOMError, match="[Oo][Oo][Mm]"):
+        with pytest.raises(RuntimeFailure, match="[Oo][Oo][Mm]") as exc_info:
             await runner._run_job(
                 hook,
                 release,
                 inputs,
                 work_dir,
             )
+        assert exc_info.value.kind is FailureKind.OOM
 
     @pytest.mark.asyncio
     async def test_nonzero_exit(self, tmp_path: Path):
@@ -692,13 +694,15 @@ class TestExecutionAndCleanup:
         work_dir.mkdir(parents=True)
         inputs = HookInputs(records=[HookRecord(id="test", metadata={})], run_id=_RUN_ID)
 
-        with pytest.raises(PermanentError, match="[Ee]xit"):
+        with pytest.raises(RuntimeFailure, match="[Ee]xit") as exc_info:
             await runner._run_job(
                 hook,
                 release,
                 inputs,
                 work_dir,
             )
+        assert exc_info.value.kind is FailureKind.HOOK_EXIT
+        assert exc_info.value.exit_code == 1
 
     @pytest.mark.asyncio
     async def test_orphan_running_job_attaches(self, tmp_path: Path):

--- a/server/tests/unit/infrastructure/k8s/test_k8s_ingester_runner.py
+++ b/server/tests/unit/infrastructure/k8s/test_k8s_ingester_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from osa.config import K8sConfig
-from osa.domain.shared.error import OOMError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.source import IngesterDefinition, IngesterLimits
 from osa.domain.shared.model.srn import ConventionSlug
 from osa.domain.shared.port.ingester_runner import IngesterInputs
@@ -398,8 +398,9 @@ class TestSourceLifecycle:
         files_dir.mkdir(parents=True)
         inputs = IngesterInputs(convention_id=_CONV_SLUG)
 
-        with pytest.raises(TransientError, match="[Tt]imed out|[Dd]eadline"):
+        with pytest.raises(RuntimeFailure, match="[Tt]imed out|[Dd]eadline") as exc_info:
             await runner._run_job(ingester, inputs, work_dir, files_dir)
+        assert exc_info.value.kind is FailureKind.TIMEOUT
 
     @pytest.mark.asyncio
     async def test_oom_raises_oom_error(self, tmp_path: Path):
@@ -453,8 +454,67 @@ class TestSourceLifecycle:
         files_dir.mkdir(parents=True)
         inputs = IngesterInputs(convention_id=_CONV_SLUG)
 
-        with pytest.raises(OOMError, match="[Oo]OM"):
+        with pytest.raises(RuntimeFailure, match="[Oo]OM") as exc_info:
             await runner._run_job(ingester, inputs, work_dir, files_dir)
+        assert exc_info.value.kind is FailureKind.OOM
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_is_an_upstream_failure(self, tmp_path: Path):
+        """Ingester non-zero exit is usually an upstream API failure — the
+        cause kind must say UPSTREAM (retryable), not HOOK_EXIT."""
+        config = _make_config(data_mount_path=str(tmp_path))
+        runner = K8sIngesterRunner(api_client=MagicMock(), config=config, s3=_make_s3_mock())
+
+        batch_api = AsyncMock()
+        core_api = AsyncMock()
+        runner._batch_api = batch_api
+        runner._core_api = core_api
+
+        job_list = MagicMock()
+        job_list.items = []
+        batch_api.list_namespaced_job.return_value = job_list
+        batch_api.create_namespaced_job.return_value = MagicMock()
+
+        pod = MagicMock()
+        pod.status.phase = "Running"
+        pod.status.container_statuses = None
+        pod_list = MagicMock()
+        pod_list.items = [pod]
+
+        failed_job = MagicMock()
+        condition = MagicMock()
+        condition.type = "Failed"
+        condition.status = "True"
+        condition.reason = "BackoffLimitExceeded"
+        failed_job.status.conditions = [condition]
+        failed_job.status.succeeded = None
+        failed_job.status.failed = 1
+        batch_api.read_namespaced_job.return_value = failed_job
+
+        exit_pod = MagicMock()
+        exit_pod.status.phase = "Failed"
+        terminated = MagicMock()
+        terminated.reason = None
+        terminated.exit_code = 3
+        container_status = MagicMock()
+        container_status.state.terminated = terminated
+        exit_pod.status.container_statuses = [container_status]
+        exit_pod_list = MagicMock()
+        exit_pod_list.items = [exit_pod]
+
+        core_api.list_namespaced_pod.side_effect = [pod_list, exit_pod_list]
+
+        ingester = _make_ingester()
+        work_dir = tmp_path / "sources" / "localhost_conv1" / "staging" / "run1"
+        work_dir.mkdir(parents=True)
+        files_dir = work_dir / "files"
+        files_dir.mkdir(parents=True)
+        inputs = IngesterInputs(convention_id=_CONV_SLUG)
+
+        with pytest.raises(RuntimeFailure, match="[Ee]xit") as exc_info:
+            await runner._run_job(ingester, inputs, work_dir, files_dir)
+        assert exc_info.value.kind is FailureKind.UPSTREAM
+        assert exc_info.value.exit_code == 3
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/unit/infrastructure/test_oci_hook_runner.py
+++ b/server/tests/unit/infrastructure/test_oci_hook_runner.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from osa.domain.shared.error import OOMError, PermanentError, TransientError
+from osa.domain.shared.failure import FailureKind, RuntimeFailure
 from osa.domain.shared.model.hook import (
     ColumnDef,
     HookIdentity,
@@ -251,9 +251,11 @@ class TestContainerLifecycle:
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
-        with pytest.raises(PermanentError, match="[Ee]xit") as exc_info:
+        with pytest.raises(RuntimeFailure, match="[Ee]xit") as exc_info:
             await runner.run(hook, release, inputs, output_dir)
 
+        assert exc_info.value.kind is FailureKind.HOOK_EXIT
+        assert exc_info.value.exit_code == 1
         # Logs ride on the typed container_logs field, not embedded in the
         # message — the message must not leak tenant output to operator logs.
         assert exc_info.value.container_logs == "Error: something went wrong"
@@ -279,9 +281,10 @@ class TestContainerLifecycle:
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
-        with pytest.raises(OOMError, match="[Oo][Oo][Mm]") as exc_info:
+        with pytest.raises(RuntimeFailure, match="[Oo][Oo][Mm]") as exc_info:
             await runner.run(hook, release, inputs, output_dir)
 
+        assert exc_info.value.kind is FailureKind.OOM
         # OOM logs are captured to the typed field for the tenant-scoped artifact.
         assert exc_info.value.container_logs == "killed: out of memory"
 
@@ -311,8 +314,9 @@ class TestContainerLifecycle:
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
-        with pytest.raises(TransientError, match="[Tt]imed out"):
+        with pytest.raises(RuntimeFailure, match="[Tt]imed out") as exc_info:
             await runner.run(hook, release, inputs, output_dir)
+        assert exc_info.value.kind is FailureKind.TIMEOUT
 
     @pytest.mark.asyncio
     async def test_rejection_via_progress(self, tmp_path: Path):
@@ -503,5 +507,6 @@ class TestContainerConfig:
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
-        with pytest.raises(TransientError, match="Docker error"):
+        with pytest.raises(RuntimeFailure, match="Docker error") as exc_info:
             await runner.run(hook, release, inputs, output_dir)
+        assert exc_info.value.kind is FailureKind.RUNTIME


### PR DESCRIPTION
Closes #152.

## What & why

A single error hierarchy (`TransientError` / `PermanentError` / `OOMError`) was being asked to encode three independent concerns at once — **what happened** (the cause), **what to do** (the disposition), and **blast radius** — and deciding all of it at the runner boundary, where the retry count, memory ceiling, and run state aren't known. Symptoms: `OOMError` was a "permanent" error secretly intercepted for a memory-bump retry (the type lied); an unpullable image failed every batch one-by-one instead of aborting the run; and a failed ingestion carried no queryable explanation.

This PR separates the three concerns:

- **Facts** — runners raise `RuntimeFailure(kind, …)` describing only *what happened* (`domain/shared/failure.py`). No disposition.
- **Policy** — one injected, pure `FailurePolicy.decide(failure, PriorAttempts) → Decision` maps facts to a verb. The single place the rules live; unit-tested as a decision matrix with zero infrastructure.
- **Action** — handlers execute the verb (`Retry` / `RetryWithMoreMemory` / `GiveUp` / `AbortRun`). Blast radius becomes *which verb the policy picks*, not a property anything carries.

## Acceptance criteria

- [x] Runtime failures modelled as observation → policy → action; decision logic covered by unit tests written first (TDD).
- [x] OOM and retry-budget behaviour expressed through the policy, not error subclasses intercepted out of band.
- [x] A deterministic environmental failure (image pull / RBAC / bad config) aborts the ingest run and stops scheduling further batches.
- [x] `GET /ingestions/{id}` exposes a human `failure_reason` and machine `failure_kind`; migration adds the columns; the failure path populates them.
- [x] Existing transient-retry and per-batch give-up behaviour preserved for the cases that should keep it.

## Key design decisions (divergences from the issue sketch)

- **Decisions execute in the ingest handlers, not the `Worker`.** The worker is generic event infra shared by every handler, so `RunHooks`/`RunIngester` gather → decide → execute. The `Retry` verb is executed by re-raising the worker's delivery-control exception — the correct seam; the generic worker must not learn the `Decision` vocabulary.
- **Budget split (the issue's crux):** the outbox/worker keeps the transient redelivery budget (`delivery.retry_count`); the policy owns only the OOM memory-bump budget. So `PriorAttempts` carries just `memory_bumps` and `Retry` has no delay.
- **`GiveUp` ≠ fail-the-batch for hooks** — a terminally-failed hook records an ERROR provenance run while the batch still publishes records that passed other hooks (preserves #145).
- **Any image-pull failure aborts** — a registry 5xx isn't cheaply distinguishable from a private image, so both abort; OCI registry pull errors also moved from blind-retry to abort.
- **Deposition disposition unchanged** — for a single-record deposition, `GiveUp`/`AbortRun` collapse to "fail this validation," and the only genuine gap (retrying transient failures) is gated on making deposition idempotent under redelivery. Tracked as a fast-follow in #155.

## Testing

- **1287 unit tests** pass (new `FailurePolicy` decision-matrix suite + updated runner/handler/service tests, all TDD red-first).
- **145 integration tests** pass on a fresh migrated PostgreSQL; `alembic check` reports zero drift (the `ingest_runs` columns were folded into the single pre-launch `initial_schema` migration per the born-correct-schema policy).
- `ruff` and `ty` clean (the `assert_never` exhaustiveness in `RunIngester`'s decision match is enforced by `ty`).

## Follow-ups (out of scope)

- #155 — deposition validation should retry transient infra failures (needs idempotent redelivery first).
- Pre-flight image-reachability check at `POST /conventions` deploy (catch an unpullable image before any ingestion starts).