### PR TITLE
fix: build /openapi.json — drop `from __future__ import annotations` from raw-Response route modules

### DIFF
--- a/server/osa/application/api/rest/skill.py
+++ b/server/osa/application/api/rest/skill.py
@@ -6,8 +6,6 @@ on the versioned data surface. Thin routes: handler → JSON / markdown
 Response — no business logic here.
 """
 
-from __future__ import annotations
-
 from dishka.integrations.fastapi import DishkaRoute, FromDishka
 from fastapi import APIRouter, Request, Response
 

--- a/server/osa/application/api/v1/routes/data/reference.py
+++ b/server/osa/application/api/v1/routes/data/reference.py
@@ -6,8 +6,6 @@ before the ``/{schema}`` manifest catch-all (longest-suffix-first);
 resolution reuses ``resolve_schema`` (unknown/reserved ids → 404).
 """
 
-from __future__ import annotations
-
 from dishka.integrations.fastapi import DishkaRoute, FromDishka
 from fastapi import APIRouter, Response
 

--- a/server/osa/application/api/v1/routes/hooks.py
+++ b/server/osa/application/api/v1/routes/hooks.py
@@ -7,8 +7,6 @@ payload (the hook is identified by the path). All business logic lives in
 centrally in ``application/api/v1/errors.py``.
 """
 
-from __future__ import annotations
-
 from typing import Any
 from uuid import UUID
 

--- a/server/tests/contract/test_openapi_schema.py
+++ b/server/tests/contract/test_openapi_schema.py
@@ -1,0 +1,46 @@
+"""DB-free contract test: the OpenAPI schema must build.
+
+FastAPI generates the OpenAPI schema lazily on first request to ``/openapi.json``
+(and ``/docs``/``/redoc``, and the #151 root-discovery doc advertises
+``openapi_url``). A route returning a raw ``Response`` subclass under
+``from __future__ import annotations`` makes FastAPI try to schematize the
+stringified return annotation, which 500s during schema generation while the
+routes themselves keep working — so the rest of the suite never caught it.
+
+This is the durable backstop: it fails however the regression is reintroduced.
+"""
+
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# create_app() reads Config() at call time; provide the env it needs so this
+# test is self-sufficient regardless of how the contract job is configured.
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-for-contract-tests-minimum-32-chars")
+
+
+def _app():
+    from osa.application.api.rest.app import create_app
+
+    # A fresh app per test so FastAPI's cached ``openapi_schema`` can't mask a
+    # generation failure between tests.
+    return create_app()
+
+
+def test_openapi_schema_builds():
+    """The tightest reproduction: schema generation must not raise."""
+    schema = _app().openapi()
+    assert schema["openapi"].startswith("3.")
+    assert schema["paths"]
+
+
+@pytest.mark.asyncio
+async def test_openapi_json_endpoint_returns_200():
+    """End-to-end proof the 500 is gone."""
+    client = AsyncClient(transport=ASGITransport(app=_app()), base_url="http://test")
+    async with client:
+        resp = await client.get("/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json()["openapi"].startswith("3.")


### PR DESCRIPTION
## Problem

`GET /openapi.json` returned **500** in the running server (reproduced on the pilot at `:8000`), taking `/docs`, `/redoc`, and the root-discovery document (which advertises `openapi_url`) down with it. FastAPI builds the OpenAPI schema lazily on first request and walks every route. Three handlers return a raw Starlette/FastAPI `Response` subclass **and** live in modules with `from __future__ import annotations` (PEP 563), so the return annotation reaches FastAPI as the string `"StreamingResponse"` / `"Response"`. On the current pins (`fastapi 0.128.0` + `pydantic 2.12.5`) FastAPI fails to resolve that forward ref back to a `Response` subclass, treats it as a **response model**, and pydantic raises `class-not-fully-defined` while generating the schema:

```
TypeAdapter[Annotated[ForwardRef('StreamingResponse'), FieldInfo(annotation=NoneType, required=True)]]
is not fully defined ... call .rebuild()
```

The routes themselves work fine (they just return the stream); only *schema generation* breaks — which is why the test suite, which never requested `/openapi.json`, stayed green.

## Fix

Remove `from __future__ import annotations` from the three affected route modules:
- `osa/application/api/rest/skill.py` — `/SKILL.md`
- `osa/application/api/v1/routes/data/reference.py` — `/data/{schema}.md`
- `osa/application/api/v1/routes/hooks.py` — `/runs/{run_id}/logs`

The annotation then evaluates eagerly to the real class, so FastAPI recognizes the `Response` subclass and skips schema generation natively — matching the healthy raw-Response routes (`depositions`/`conventions` downloads) that never used the import. No `response_model=None` marker, no dependency changes.

**Root cause, not a workaround:** those routes were the odd ones out for having the import; route modules gain nothing from PEP 563 (FastAPI must evaluate their annotations at runtime regardless) and it introduces exactly this footgun. Verified per file that removal is safe — no `TYPE_CHECKING` blocks, forward references, or masked circular imports, so eager evaluation is a no-op beyond the fix.

## Test

Adds `tests/contract/test_openapi_schema.py` (DB-free contract job) as the durable backstop — the gap that let this regress, since nothing built the schema:
- `test_openapi_schema_builds()` — `create_app().openapi()` builds (reproduced the exact `PydanticUserError` before the fix).
- `test_openapi_json_endpoint_returns_200()` — `/openapi.json` → 200 end-to-end.

## Verification

- Contract suite: 37 passed (incl. the 2 new tests); ruff + ty clean.
- Live pilot after rebuild: `/openapi.json` → **200** (88KB, openapi 3.1.0, 51 paths), `/docs` renders — both were 500.

## Follow-up (not included)

A scoped guard against re-adding `from __future__ import annotations` to route modules was considered and skipped — the regression test already prevents the breakage from shipping.