### PR TITLE
feat: observability — OpenTelemetry metrics, logs, traces, and health endpoints

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,264 @@
+# Observability (#158)
+
+OSA exports metrics, structured logs, and distributed traces through a single
+OpenTelemetry pipeline (built on the bundled Logfire SDK). This guide is for
+operators running a self-hosted node: how to scrape or push telemetry, the full
+metric catalog, the health/readiness contract, and how request traces flow
+through the async outbox.
+
+## Overview
+
+A running node emits three OTel signals:
+
+- **Metrics** — an `osa_*` family of counters, histograms, and gauges (full
+  table below), plus the auto-instrumented `http.server.request.duration`
+  histogram for every HTTP request.
+- **Logs** — the stdlib root logger is bridged into the pipeline, so ordinary
+  `logger.info(...)` calls become structured log records.
+- **Traces** — spans for HTTP requests and worker dispatch, linked across the
+  outbox (see [Traces](#traces)).
+
+There are three ways to consume this, and they compose — you can scrape *and*
+push at the same time:
+
+1. **Scrape `GET /metrics`** (Prometheus text format). Enabled by default; a
+   Prometheus server pulls metrics on its own schedule. This is the pull model
+   and covers metrics only (not logs or traces).
+2. **Push OTLP to your own collector.** Set
+   `OSA_OBSERVABILITY__OTLP_ENDPOINT` (and optionally
+   `OSA_OBSERVABILITY__OTLP_TOKEN`) and the node pushes all three signals
+   (metrics, logs, traces) over OTLP/HTTP to a collector you run — an
+   OpenTelemetry Collector, Grafana Alloy, Grafana Cloud, Honeycomb, etc.
+3. **Managed hosting.** On a platform-hosted node, the `OSA_OBSERVABILITY__*`
+   env vars are injected for you and telemetry lands in the platform's
+   collector. No action required; the same knobs documented here still apply if
+   you need to override behavior.
+
+## Configuration reference
+
+All settings live under the `OSA_OBSERVABILITY__*` nested-env prefix (the `__`
+double-underscore is the nested delimiter; these also map to an `observability:`
+block in a YAML config file).
+
+| Env var | Type | Default | Meaning |
+|---|---|---|---|
+| `OSA_OBSERVABILITY__OTLP_ENDPOINT` | URL string \| unset | unset | Base OTLP/HTTP endpoint. When set, metrics, logs, and traces are pushed to `{endpoint}/v1/{signal}`. Unset disables push export entirely. |
+| `OSA_OBSERVABILITY__OTLP_TOKEN` | secret string \| unset | unset | Bearer token sent as the `Authorization: Bearer <token>` header on every OTLP export. Treated as a secret — never logged. |
+| `OSA_OBSERVABILITY__PROMETHEUS_ENABLED` | bool | `true` | Serve `GET /metrics` for Prometheus pull scraping. Set `false` to disable the endpoint (it then returns 404). |
+| `OSA_OBSERVABILITY__TRACE_SAMPLE_RATE` | float in `[0.0, 1.0]` | `1.0` | Head sampling rate for traces. `1.0` samples everything; `0.1` keeps ~10%; `0.0` disables tracing. |
+
+### Identity labels — `OTEL_RESOURCE_ATTRIBUTES`
+
+Node identity is **not** an OSA-specific setting. It rides the standard
+OpenTelemetry `OTEL_RESOURCE_ATTRIBUTES` env var, which the pipeline reads at
+startup and stamps onto every metric, log, and span as resource attributes. Use
+it to label telemetry with which node produced it:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=osa.node_domain=archive.example.edu,deployment.environment=production
+```
+
+The `service.name` (from the node name) and `service.version` (the OSA release)
+are set automatically — you do not need to add them here.
+
+## Quick starts
+
+### Scrape with Prometheus (default)
+
+Nothing to configure on the OSA side — `/metrics` is served unversioned at the
+root by default. Point your Prometheus at it (the server listens on `:8000`):
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: osa
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["osa-host:8000"]
+```
+
+`/metrics` renders standard Prometheus exposition text (`CONTENT_TYPE_LATEST`)
+and exposes only OSA's own collector — not the process/platform collectors — so
+you get a clean `osa_*` surface plus `http_server_request_duration_*`.
+
+### Push OTLP to a collector
+
+Set the endpoint (and a token if your collector requires one) in the node's
+environment. Export is **OTLP/HTTP with protobuf encoding**; the per-signal
+paths (`/v1/traces`, `/v1/metrics`, `/v1/logs`) are appended automatically, so
+give the **base** endpoint only.
+
+Local OpenTelemetry Collector:
+
+```bash
+OSA_OBSERVABILITY__OTLP_ENDPOINT=http://otel-collector:4318
+```
+
+Grafana Cloud (or any authenticated OTLP/HTTP backend):
+
+```bash
+OSA_OBSERVABILITY__OTLP_ENDPOINT=https://otlp-gateway-prod-us-central-0.grafana.net/otlp
+OSA_OBSERVABILITY__OTLP_TOKEN=glc_eyJ...      # sent as: Authorization: Bearer glc_eyJ...
+```
+
+Both consumption modes can run together: keep `/metrics` for a local Prometheus
+while also pushing traces and logs to a remote collector.
+
+## Metric reference
+
+Every metric name is owned by exactly one emitter, and every label value is
+drawn from a bounded enum (below), so time-series cardinality stays finite. The
+`_total` suffix marks counters in Prometheus.
+
+### Hook execution
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `osa_hook_runs_total` | counter | `hook`, `status` | Completed hook executions, by hook and terminal run status. |
+| `osa_hook_run_duration_seconds` | histogram | `hook`, `status` | Wall-clock duration of hook executions. |
+| `osa_hook_failures_total` | counter | `hook`, `kind`, `decision` | Hook failures, by observed cause (`kind`) and the policy decision taken (`decision`). |
+| `osa_hook_oom_retries_total` | counter | `hook` | Out-of-memory retries (memory bumps) performed. Only incremented when a run actually bumped memory. |
+
+### Ingest
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `osa_ingest_batches_total` | counter | `outcome`, `kind` | Ingest batches reaching a terminal state. `outcome` ∈ `completed`\|`failed`; `kind` is the failure cause on failed batches, else `none`. |
+| `osa_records_published_total` | counter | — | Records published by completed ingest batches. |
+| `osa_ingest_runs_total` | counter | `status`, `kind` | Ingest runs reaching a terminal status. `kind` is the failure cause on failed runs, else `none`. |
+
+### Outbox / event delivery
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `osa_deliveries_total` | counter | `consumer_group`, `status` | Terminal outbox dispatch-attempt outcomes, by consumer group and delivery status. |
+| `osa_dispatch_duration_seconds` | histogram | `consumer_group` | Wall-clock duration of a single delivery dispatch. |
+
+### Outbox / worker gauges (periodic sampler)
+
+Sampled every 15 seconds by a background task in the worker pool. On PostgreSQL
+these reflect live queue depth and pool pressure; the DB-pool gauges are skipped
+on SQLite (no connection pool to sample).
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `osa_outbox_lag_seconds` | gauge | — | Age of the oldest *eligible* pending delivery (claimable now). `0` when the queue is empty. |
+| `osa_outbox_pending` | gauge | `consumer_group` | Pending (unclaimed) deliveries per consumer group. |
+| `osa_outbox_failed` | gauge | `consumer_group` | Failed deliveries per consumer group. |
+| `osa_db_pool_checked_out` | gauge | — | Connections currently checked out of the SQLAlchemy pool. |
+| `osa_db_pool_size` | gauge | — | Configured base size of the connection pool. |
+| `osa_db_pool_overflow` | gauge | — | Overflow connections open beyond the base pool size. |
+| `osa_workers_busy` | gauge | — | Worker loops currently processing a batch. |
+| `osa_workers_total` | gauge | — | Total worker loops in the pool. |
+
+### API edge
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `osa_unhandled_errors_total` | counter | — | Unhandled exceptions that reached the global error handler (surfaced as 500s). |
+
+### HTTP (auto-instrumented)
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `http.server.request.duration` | histogram | OTel HTTP semconv (method, route, status code, …) | Request latency for every HTTP route. Emitted by the FastAPI instrumentation — no OSA code. |
+
+### Label vocabularies
+
+Label values come straight from these enums:
+
+- **`status`** on `osa_hook_runs_total` / `osa_hook_run_duration_seconds`
+  (`HookRunStatus`): `passed`, `warnings`, `failed`, `error`.
+- **`kind`** on hook and ingest failures (`FailureKind`): `image_pull`, `rbac`,
+  `config`, `oom`, `timeout`, `upstream`, `hook_exit`, `runtime`, `unknown`. On
+  ingest metrics, `none` additionally marks the no-failure case.
+- **`decision`** on `osa_hook_failures_total` (`DecisionKind`): `retry`,
+  `retry_with_more_memory`, `give_up`, `abort_run`.
+- **`status`** on `osa_ingest_runs_total` (`IngestStatus`): `pending`,
+  `running`, `completed`, `failed`.
+- **`outcome`** on `osa_ingest_batches_total`: `completed`, `failed`.
+- **`status`** on `osa_deliveries_total` (`DeliveryStatus`): `pending`,
+  `claimed`, `delivered`, `failed`, `skipped`.
+- **`consumer_group`** on delivery metrics: the event-handler class name that
+  processed the delivery — a fixed set of registered handlers (e.g. `RunHooks`,
+  `PublishBatch`, `RunIngester`, `ConvertDepositionToRecord`).
+- **`hook`**: the hook's registered name.
+
+## Health endpoints
+
+Two endpoints under the versioned API, both unauthenticated and excluded from
+request tracing:
+
+### `GET /api/v1/health` — liveness
+
+Cheap liveness probe. Always returns `200` if the process is up:
+
+```json
+{ "status": "ok", "version": "1.4.2" }
+```
+
+`version` is the running OSA release (the same value stamped onto telemetry as
+`service.version`).
+
+### `GET /api/v1/ready` — readiness
+
+Component-structured readiness. Checks the database (`SELECT 1`), the worker
+pool (running with no dead workers), and the configured runner (Kubernetes
+health check; reported `unchecked` for the local OCI runner). Returns `200` when
+every component is healthy, `503` when any is degraded. Individual check
+failures become a component error — they never surface as a 500.
+
+```json
+{
+  "status": "ready",
+  "version": "1.4.2",
+  "components": {
+    "db": { "status": "ok", "detail": null },
+    "workers": { "status": "ok", "detail": null },
+    "runner": { "status": "unchecked", "detail": "oci runner is not health-checked" }
+  }
+}
+```
+
+Each component's `status` is one of `ok`, `error`, or `unchecked`. A `degraded`
+top-level status (HTTP 503) means at least one component reports `error` — wire
+this endpoint to your orchestrator's readiness probe so a node with a dead DB or
+worker pool is pulled from rotation.
+
+## Traces
+
+A trace follows one logical operation across the async boundary that the outbox
+introduces. An inbound HTTP request opens a request span; when its handler
+appends an event to the outbox, the request's trace context (a W3C
+`traceparent`) is captured and stored on the delivery row. Later — possibly in a
+different worker, out of band — the worker claims that delivery and opens a
+`worker.dispatch` span, and any hook or child spans produced while handling the
+event nest under it. Because events appended *during* handling capture the
+dispatch span as *their* trace context in turn, multi-hop chains
+(request → RunHooks → PublishBatch → …) fall out automatically: each hop links
+to the previous one.
+
+The join is modeled with **span links, not parent/child**. A single worker poll
+claims a *batch* of deliveries that can originate from many different requests,
+so there is no single parent to attach to — instead the dispatch span carries a
+link to each originating span. NULL trace context (events created outside any
+request, e.g. from the CLI or a cron loop) simply produces no link, and a
+malformed `traceparent` is skipped with a warning without blocking delivery.
+Sampling is head-based via `OSA_OBSERVABILITY__TRACE_SAMPLE_RATE` — the decision
+is made once at the root and honored consistently down the chain.
+
+## Security notes
+
+- **`/metrics` is unauthenticated.** The Prometheus endpoint has no auth gate by
+  design (Prometheus scraping convention). If the node is reachable from an
+  untrusted network, either disable it
+  (`OSA_OBSERVABILITY__PROMETHEUS_ENABLED=false`) and push OTLP to your own
+  collector instead, or shield `/metrics` at your reverse proxy / ingress (allow
+  only your Prometheus source, or require an auth header at the proxy). OSA's
+  metric labels are bounded enums and carry no record contents, but queue depths
+  and error counts are still operational information you may not want public.
+- **The OTLP token is a secret.** `OSA_OBSERVABILITY__OTLP_TOKEN` is stored as a
+  secret and only ever leaves the process as the `Authorization: Bearer` header
+  on OTLP requests — it is never written to logs (telemetry startup logs the
+  endpoint, never the token). Supply it via your secret manager / injected env,
+  not in a checked-in config file.

--- a/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
+++ b/server/migrations/versions/c6d9f4c0c3ab_initial_schema.py
@@ -45,6 +45,7 @@ def upgrade() -> None:
         sa.Column("event_type", sa.String(length=128), nullable=False),
         sa.Column("payload", sa.JSON(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("trace_context", sa.String(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(

--- a/server/osa/application/api/rest/app.py
+++ b/server/osa/application/api/rest/app.py
@@ -36,6 +36,7 @@ from osa.domain.shared.error import OSAError
 from osa.domain.shared.event import EventHandler
 from osa.infrastructure.event.worker import WorkerPool
 from osa.infrastructure.persistence.seed import ensure_system_user
+from osa.infrastructure.telemetry.api import ApiInstrumentation
 from osa.infrastructure.telemetry.setup import bootstrap
 from osa.util.di.fastapi import setup_dishka
 
@@ -215,6 +216,14 @@ def create_app(
             request.method,
             request.url.path,
         )
+        # Count the unhandled error for observability. A telemetry failure must
+        # never mask the 500 response, so resolution + emission is guarded and
+        # only logged.
+        try:
+            instrumentation = await request.app.state.dishka_container.get(ApiInstrumentation)
+            instrumentation.unhandled_error()
+        except Exception:
+            logger.warning("Failed to record unhandled-error metric", exc_info=True)
         return JSONResponse(
             status_code=500,
             content={"detail": "Internal server error"},

--- a/server/osa/application/api/rest/app.py
+++ b/server/osa/application/api/rest/app.py
@@ -36,6 +36,7 @@ from osa.domain.shared.error import OSAError
 from osa.domain.shared.event import EventHandler
 from osa.infrastructure.event.worker import WorkerPool
 from osa.infrastructure.persistence.seed import ensure_system_user
+from osa.infrastructure.telemetry.setup import bootstrap
 from osa.util.di.fastapi import setup_dishka
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,12 @@ async def lifespan(app: FastAPI):
     async with worker_pool:
         yield
 
+    # Flush buffered telemetry (span/metric/log exporters) before teardown.
+    # NOT logfire.shutdown(): that tears down the process-global providers,
+    # which would break later create_app() instances in the same test process
+    # (the bootstrap is configure-once and never re-runs).
+    logfire.force_flush()
+
     await container.close()
 
 
@@ -132,39 +139,9 @@ def create_app(
     # Refuse to boot if the dev JWT secret is misconfigured for the deploy.
     _check_dev_secret_safety(config)
 
-    # Configure logfire as the single logging system
-    import logging as _logging
-
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-
-    from osa.infrastructure.logging import OSAConsoleExporter
-
-    logfire.configure(
-        send_to_logfire="if-token-present",
-        service_name=config.name,
-        console=False,  # Disable default console — we use OSAConsoleExporter
-        inspect_arguments=False,
-        additional_span_processors=[
-            SimpleSpanProcessor(
-                OSAConsoleExporter(
-                    output=sys.stderr,
-                    include_timestamp=True,
-                    min_log_level=config.logging.level,
-                )
-            ),
-        ],
-    )
-
-    # Route Python logging through logfire so old-style logger.info() calls
-    # appear in the same output stream
-    root = _logging.getLogger()
-    root.setLevel(config.logging.level.upper())
-    for h in root.handlers[:]:
-        root.removeHandler(h)
-    root.addHandler(logfire.LogfireLoggingHandler())
-
-    # Suppress duplicate access logs — logfire FastAPI instrumentation handles HTTP logging
-    _logging.getLogger("uvicorn.access").setLevel(_logging.WARNING)
+    # Configure the process-global telemetry pipeline (logfire + OTel exporters).
+    # Idempotent across repeated create_app() calls in one process.
+    bootstrap.configure(config)
 
     logfire.info("Starting OSA server: {name} v{version}", name=config.name, version=config.version)
 

--- a/server/osa/application/api/rest/app.py
+++ b/server/osa/application/api/rest/app.py
@@ -21,6 +21,7 @@ from osa.application.api.v1.routes import (
     hooks,
     ingestions,
     health,
+    metrics,
     ontologies,
     schemas,
     stats,
@@ -159,7 +160,9 @@ def create_app(
     logfire.instrument_httpx()
     logfire.instrument_fastapi(
         app_instance,
-        excluded_urls="/api/v1/health",
+        # Probes and the scrape endpoint are high-frequency and uninteresting as
+        # traces; the OTel FastAPI instrumentor takes a comma-separated regex list.
+        excluded_urls="/api/v1/health,/api/v1/ready,/metrics",
     )
 
     # Setup dependency injection
@@ -184,9 +187,11 @@ def create_app(
     app_instance.include_router(validation.router, prefix="/api/v1")
     app_instance.include_router(data_routes.router, prefix="/api/v1")
 
-    # Unversioned root surface — GET / and GET /SKILL.md (#151). Included
-    # after the /api/v1 routers so nothing shadows the API prefix.
+    # Unversioned root surface — GET / and GET /SKILL.md (#151), plus GET
+    # /metrics (#158, Prometheus convention). Included after the /api/v1
+    # routers so nothing shadows the API prefix.
     app_instance.include_router(skill_routes.router)
+    app_instance.include_router(metrics.router)
 
     # POST /data/* rate limiting (slowapi). The shared limiter is attached to
     # app state and its 429 handler registered; GET routes are not limited.

--- a/server/osa/application/api/v1/routes/health.py
+++ b/server/osa/application/api/v1/routes/health.py
@@ -1,14 +1,170 @@
-"""Health check endpoint."""
+"""Liveness and readiness endpoints (#158).
 
-from fastapi import APIRouter
+``GET /health`` is a cheap liveness probe (process is up). ``GET /ready`` runs
+component checks — database, worker pool, and configured runner — and returns
+``200`` only when no checked component is failing, ``503`` otherwise. Each
+check is individually guarded so a failing dependency becomes a component
+``error`` rather than a 500. Both routes are unauthenticated and excluded from
+request tracing (see ``app.py``'s ``excluded_urls``).
+"""
 
-router = APIRouter(tags=["health"])
+import asyncio
+from typing import Literal
+
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, Request, Response
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from osa.config import Config
+from osa.infrastructure.event.worker import WorkerPool
+from osa.infrastructure.k8s.health import check_k8s_health
+from osa.infrastructure.logging import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["health"], route_class=DishkaRoute)
+
+# Component checks must answer fast so /ready is a usable orchestrator probe.
+_CHECK_TIMEOUT_S = 2.0
+
+
+class HealthResponse(BaseModel):
+    """Liveness payload."""
+
+    status: Literal["ok"]
+    version: str
+
+
+class ComponentStatus(BaseModel):
+    """One readiness component's verdict.
+
+    ``ok`` — checked and healthy. ``error`` — checked and failing (``detail``
+    carries the reason). ``unchecked`` — deliberately not probed (e.g. the OCI
+    runner, which has no cheap health check).
+    """
+
+    status: Literal["ok", "error", "unchecked"]
+    detail: str | None = None
+
+
+class ReadyResponse(BaseModel):
+    """Readiness payload: overall verdict plus per-component detail."""
+
+    status: Literal["ready", "degraded"]
+    version: str
+    components: dict[str, ComponentStatus]
+
+
+class ReadinessProbe:
+    """Runs the per-component readiness checks for ``GET /ready``.
+
+    A component is ``error`` on any exception — never a 500 out of the route.
+    ``unchecked`` (e.g. the OCI runner) is neutral: it neither proves nor
+    degrades readiness. Any *checked* component that errors degrades.
+    """
+
+    def __init__(self, config: Config, session: AsyncSession, pool: WorkerPool) -> None:
+        self._config = config
+        self._session = session
+        self._pool = pool
+
+    async def run(self, request: Request) -> dict[str, ComponentStatus]:
+        return {
+            "db": await self._check_db(),
+            "workers": self._check_workers(),
+            "runner": await self._check_runner(request),
+        }
+
+    async def _check_db(self) -> ComponentStatus:
+        """``SELECT 1`` through the request's UOW session, time-boxed."""
+        try:
+            await asyncio.wait_for(
+                self._session.execute(text("SELECT 1")), timeout=_CHECK_TIMEOUT_S
+            )
+            return ComponentStatus(status="ok")
+        except Exception as exc:  # any failure is a component error, never a 500
+            return ComponentStatus(status="error", detail=str(exc))
+
+    def _check_workers(self) -> ComponentStatus:
+        """Worker pool health.
+
+        "ok" means the pool has started (at least one worker's background task
+        is running) and every worker's task is still alive. Under a TestClient
+        without the lifespan the pool is never started, so this reports
+        ``error`` with "worker pool not running".
+        """
+        try:
+            workers = self._pool.workers
+            if not workers or not any(w.is_alive for w in workers):
+                return ComponentStatus(status="error", detail="worker pool not running")
+            dead = [w.name for w in workers if not w.is_alive]
+            if dead:
+                return ComponentStatus(
+                    status="error", detail=f"workers not running: {', '.join(dead)}"
+                )
+            return ComponentStatus(status="ok")
+        except Exception as exc:
+            return ComponentStatus(status="error", detail=str(exc))
+
+    async def _check_runner(self, request: Request) -> ComponentStatus:
+        """Runner health.
+
+        On the OCI backend a docker-socket probe is out of scope, so the runner
+        is reported ``unchecked``. On the K8s backend the real infra check
+        (``check_k8s_health``) runs, time-boxed — hooks cannot run without it,
+        so an error here degrades readiness.
+        """
+        if self._config.runner.backend != "k8s":
+            return ComponentStatus(status="unchecked", detail="oci runner is not health-checked")
+
+        try:
+            # Optional dependency: only importable when the k8s extra is installed,
+            # which is guaranteed on the k8s backend.
+            from kubernetes_asyncio.client import ApiClient, BatchV1Api, CoreV1Api
+
+            container = request.app.state.dishka_container
+            api_client = await container.get(ApiClient)
+            k8s = self._config.runner.k8s
+            await asyncio.wait_for(
+                check_k8s_health(
+                    BatchV1Api(api_client),
+                    CoreV1Api(api_client),
+                    namespace=k8s.namespace,
+                    pvc_name=k8s.data_pvc_name,
+                ),
+                timeout=_CHECK_TIMEOUT_S,
+            )
+            return ComponentStatus(status="ok")
+        except Exception as exc:
+            return ComponentStatus(status="error", detail=str(exc))
 
 
 @router.get("/health")
-async def health() -> dict:
-    """Health check endpoint."""
-    return {
-        "status": "healthy",
-        "version": "0.1.0",
-    }
+async def health(config: FromDishka[Config]) -> HealthResponse:
+    """Liveness probe — always ``200`` while the process is serving."""
+    return HealthResponse(status="ok", version=config.version)
+
+
+@router.get("/ready")
+async def ready(
+    config: FromDishka[Config],
+    session: FromDishka[AsyncSession],
+    pool: FromDishka[WorkerPool],
+    request: Request,
+    response: Response,
+) -> ReadyResponse:
+    """Readiness probe: DB + worker-pool + runner checks.
+
+    Returns ``200`` when every *checked* component is healthy (``unchecked``
+    is neutral), ``503`` when any checked component errors.
+    """
+    components = await ReadinessProbe(config, session, pool).run(request)
+    is_ready = all(c.status != "error" for c in components.values())
+    response.status_code = 200 if is_ready else 503
+    return ReadyResponse(
+        status="ready" if is_ready else "degraded",
+        version=config.version,
+        components=components,
+    )

--- a/server/osa/application/api/v1/routes/metrics.py
+++ b/server/osa/application/api/v1/routes/metrics.py
@@ -1,0 +1,36 @@
+"""Prometheus scrape endpoint (#158).
+
+``GET /metrics`` renders OSA's owned Prometheus registry in the standard
+exposition format. Mounted **unversioned at the root** (Prometheus convention),
+unauthenticated, and excluded from request tracing.
+
+When Prometheus is disabled (``OSA_OBSERVABILITY__PROMETHEUS_ENABLED=false``) or
+telemetry was never configured, the bootstrap owns no registry and this returns
+``404`` — operators should push OTLP instead.
+"""
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from osa.infrastructure.telemetry.setup import bootstrap
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics")
+async def metrics() -> Response:
+    """Render the owned Prometheus registry, or 404 when disabled."""
+    registry = bootstrap.prometheus_registry
+    if registry is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "detail": (
+                    "Prometheus metrics are disabled "
+                    "(OSA_OBSERVABILITY__PROMETHEUS_ENABLED=false, or telemetry "
+                    "is not configured). Push OTLP to a collector instead."
+                )
+            },
+        )
+    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)

--- a/server/osa/application/di.py
+++ b/server/osa/application/di.py
@@ -18,6 +18,7 @@ from osa.infrastructure.http.di import HttpProvider
 from osa.infrastructure.k8s.di import RunnerProvider
 from osa.infrastructure.persistence.di import PersistenceProvider
 from osa.infrastructure.ingest.di import IngestProvider
+from osa.infrastructure.telemetry.di import TelemetryProvider
 from osa.util.di.scope import Scope
 from osa.util.paths import OSAPaths
 
@@ -54,6 +55,7 @@ def create_container(
         AuthProvider(),
         AuthInfraProvider(),
         DataProvider(),
+        TelemetryProvider(),
         *extra_providers,
         context={Config: config, OSAPaths: paths},
         scopes=Scope,  # type: ignore[arg-type]  # Custom scope class

--- a/server/osa/config.py
+++ b/server/osa/config.py
@@ -8,7 +8,14 @@ from pathlib import Path
 from typing import Any, Literal, Annotated
 
 import yaml
-from pydantic import BaseModel, BeforeValidator, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 from typing_extensions import Self
 
@@ -296,6 +303,34 @@ class DataConfig(BaseModel):
     max_page_limit: int = 1000  # page-size ceiling; over-large requests are clamped, not 422d
 
 
+class ObservabilityConfig(BaseModel):
+    """Telemetry export configuration (metrics, logs, traces).
+
+    Controls how the node exports OpenTelemetry signals (built on the bundled
+    Logfire pipeline). All fields are overridable via the nested-delimiter env
+    vars (``OSA_OBSERVABILITY__*``):
+
+    - ``OSA_OBSERVABILITY__OTLP_ENDPOINT`` — base OTLP/HTTP endpoint. When set,
+      metrics, logs, and traces are pushed to ``{endpoint}/v1/{signal}``. When
+      ``None`` (the default), push export is disabled.
+    - ``OSA_OBSERVABILITY__OTLP_TOKEN`` — bearer token sent as the
+      ``Authorization: Bearer <token>`` header on OTLP exports.
+    - ``OSA_OBSERVABILITY__PROMETHEUS_ENABLED`` — serve ``GET /metrics`` for
+      Prometheus pull scraping (default ``true``).
+    - ``OSA_OBSERVABILITY__TRACE_SAMPLE_RATE`` — head sampling rate in
+      ``[0.0, 1.0]`` (default ``1.0`` = sample everything).
+
+    Node identity resource attributes (e.g. ``service.namespace``, node domain)
+    are *not* configured here: they ride the standard ``OTEL_RESOURCE_ATTRIBUTES``
+    env var, which the telemetry pipeline reads at configure time.
+    """
+
+    otlp_endpoint: str | None = None  # base OTLP/HTTP endpoint; None disables push export
+    otlp_token: SecretStr | None = None  # bearer token sent as Authorization header
+    prometheus_enabled: bool = True  # serve GET /metrics (Prometheus pull)
+    trace_sample_rate: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
 class Config(BaseSettings):
     # Archive identity (promoted from Server model)
     name: str = "Open Science Archive"
@@ -320,6 +355,9 @@ class Config(BaseSettings):
     auth: AuthConfig = AuthConfig()  # Defaults are dev-safe; boot check enforces prod-correctness
     runner: RunnerConfig = RunnerConfig()
     data: DataConfig = DataConfig()  # /data/ read-surface filter-tree bounds
+    observability: ObservabilityConfig = (
+        ObservabilityConfig()
+    )  # telemetry export (OSA_OBSERVABILITY__*)
     host_data_dir: str | None = None  # Host path for OSA_DATA_DIR (sibling container mounts)
 
     model_config = {

--- a/server/osa/domain/ingest/handler/run_hooks.py
+++ b/server/osa/domain/ingest/handler/run_hooks.py
@@ -30,6 +30,7 @@ from osa.domain.validation.model.hook_release import HookRelease
 from osa.domain.validation.model.hook_result import HookExecution
 from osa.domain.validation.model.hook_run import HookRun, HookRunId, HookRunStatus
 from osa.domain.validation.port.hook_runner import HookInputs
+from osa.domain.validation.port.instrumentation import HookInstrumentation
 from osa.domain.validation.service.hook import HookService
 from osa.domain.validation.service.hook_registry import HookRegistryService
 from osa.infrastructure.logging import get_logger
@@ -62,6 +63,7 @@ class RunHooks(EventHandler[IngesterBatchReady]):
     outbox: Outbox
     ingest_storage: IngestStoragePort
     failure_policy: FailurePolicy
+    instrumentation: HookInstrumentation
 
     async def handle(self, event: IngesterBatchReady) -> None:
         ingest_run = await self.ingest_repo.get(event.ingest_run_id)
@@ -171,6 +173,16 @@ class RunHooks(EventHandler[IngesterBatchReady]):
             if e.failure is not None
         ]
 
+        # One metric per observed failure + the policy verb it earned. ``kind`` is
+        # a fact the execution already carries (``as_failure`` never raises here —
+        # ``decided`` holds only errored executions).
+        for e, decision in decided:
+            self.instrumentation.run_failure_decided(
+                hook=e.hook_name,
+                kind=e.as_failure().kind,
+                decision=decision.kind_label,
+            )
+
         verdict = most_severe(d for _, d in decided)
         match verdict:
             case AbortRun(reason=reason, kind=kind):
@@ -246,6 +258,14 @@ class RunHooks(EventHandler[IngesterBatchReady]):
             )
             await self.ingest_storage.write_run_ref(
                 work_dirs[e.hook_name], str(run_id), str(e.release_id)
+            )
+            # ``duration_s`` is a required field on every HookExecution (both the
+            # completed and failed constructors set it), so it is never None here.
+            self.instrumentation.run_finished(
+                hook=e.hook_name,
+                status=status,
+                duration_s=e.duration_s,
+                oom_retries=e.oom_retries,
             )
 
     async def on_exhausted(self, event: IngesterBatchReady) -> None:

--- a/server/osa/domain/ingest/port/instrumentation.py
+++ b/server/osa/domain/ingest/port/instrumentation.py
@@ -1,0 +1,34 @@
+"""IngestInstrumentation port — a domain-probe for ingest-run telemetry.
+
+One method per business fact worth measuring (a batch completed / failed; a run
+reached a terminal state). Implemented by infrastructure (an OTel adapter);
+trivially no-op-able in tests. All methods are synchronous — metric emission
+must never block ingestion — and keyword-only so call sites read as named
+facts. Labels are typed enums so metric cardinality stays bounded.
+"""
+
+from abc import abstractmethod
+from typing import Protocol
+
+from osa.domain.ingest.model.ingest_run import IngestStatus
+from osa.domain.shared.failure import FailureKind
+from osa.domain.shared.port import Port
+
+
+class IngestInstrumentation(Port, Protocol):
+    """Domain-probe for ingest-run metrics (see module docstring)."""
+
+    @abstractmethod
+    def batch_completed(self, *, published_count: int) -> None:
+        """Record a batch that completed, publishing ``published_count`` records."""
+        ...
+
+    @abstractmethod
+    def batch_failed(self, *, kind: FailureKind | None) -> None:
+        """Record a batch that failed; ``kind`` is the observed cause when known."""
+        ...
+
+    @abstractmethod
+    def run_finished(self, *, status: IngestStatus, kind: FailureKind | None) -> None:
+        """Record an ingest run reaching a terminal status (completed / failed)."""
+        ...

--- a/server/osa/domain/ingest/service/ingest.py
+++ b/server/osa/domain/ingest/service/ingest.py
@@ -12,6 +12,7 @@ from osa.domain.ingest.model.ingest_run import (
     IngestStatus,
     RunClosed,
 )
+from osa.domain.ingest.port.instrumentation import IngestInstrumentation
 from osa.domain.ingest.port.repository import IngestRunRepository
 from osa.domain.shared.error import ConflictError, NotFoundError
 from osa.domain.shared.event import EventId
@@ -31,6 +32,7 @@ class IngestService(Service):
     convention_service: ConventionService
     outbox: Outbox
     node_domain: Domain
+    instrumentation: IngestInstrumentation
 
     async def start_ingest(
         self,
@@ -129,6 +131,7 @@ class IngestService(Service):
                     published_count=published_count,
                 )
             case Applied(run):
+                self.instrumentation.batch_completed(published_count=published_count)
                 await self._check_completion(run)
 
     async def fail_batch(
@@ -150,6 +153,7 @@ class IngestService(Service):
                     reason=reason,
                 )
             case Applied(run):
+                self.instrumentation.batch_failed(kind=kind)
                 await self._check_completion(run)
                 await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
@@ -186,6 +190,7 @@ class IngestService(Service):
                     reason=reason,
                 )
             case Applied(run):
+                self.instrumentation.batch_failed(kind=kind)
                 await self._check_completion(run)
                 await self.ingest_repo.record_failure(ingest_run_id, reason=reason, kind=kind)
 
@@ -212,6 +217,9 @@ class IngestService(Service):
                     ingest_run_id=ingest_run_id,
                 )
             case Applied():
+                # Terminal metric for the abort path — the run reaches FAILED
+                # exactly once here (subsequent aborts return RunClosed).
+                self.instrumentation.run_finished(status=IngestStatus.FAILED, kind=kind)
                 log.error(
                     "[{short_id}] run ABORTED ({kind}): {reason}",
                     short_id=str(ingest_run_id)[:8],
@@ -225,6 +233,11 @@ class IngestService(Service):
         if not ingest_run.check_completion(datetime.now(UTC)):
             return
         await self.ingest_repo.save(ingest_run)
+        # Terminal metric for the natural-completion path. ``check_completion``
+        # only transitions RUNNING → COMPLETED, and it fires at most once per run
+        # (subsequent calls see a non-RUNNING status), so this can't double-count
+        # nor collide with the abort_run path (which terminalizes to FAILED).
+        self.instrumentation.run_finished(status=ingest_run.status, kind=ingest_run.failure_kind)
         await self.outbox.append(
             IngestCompleted(
                 id=EventId(uuid4()),

--- a/server/osa/domain/shared/event.py
+++ b/server/osa/domain/shared/event.py
@@ -1,6 +1,7 @@
 """Domain events, event handlers, scheduled tasks, and worker infrastructure."""
 
 from abc import ABC, ABCMeta, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum, StrEnum
@@ -154,6 +155,27 @@ class Delivery:
     event: "Event"
     retry_count: int = 0
     trace_context: str | None = None
+
+
+@dataclass(frozen=True)
+class DeliveryStats:
+    """Snapshot of outbox delivery health, used for telemetry gauges.
+
+    Attributes:
+        counts: Row count per ``(consumer_group, status)`` pair across the
+            whole deliveries table — the raw material for per-group,
+            per-status gauges.
+        oldest_pending_created_at: The ``events.created_at`` of the oldest
+            *eligible* pending delivery, or None when no work is currently
+            claimable. "Eligible pending" means
+            ``status = 'pending' AND (deliver_after IS NULL OR deliver_after <= now)``
+            — i.e. work a worker could claim right now. Deliveries scheduled
+            for later (a future ``deliver_after``) are excluded so they never
+            inflate outbox-lag measurements. Timezone-aware (UTC).
+    """
+
+    counts: Mapping[tuple[str, DeliveryStatus], int]
+    oldest_pending_created_at: datetime | None
 
 
 @dataclass(frozen=True)

--- a/server/osa/domain/shared/event.py
+++ b/server/osa/domain/shared/event.py
@@ -3,7 +3,7 @@
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import (
     Any,
     ClassVar,
@@ -49,6 +49,22 @@ class Event(Entity):
 
 
 # --- Worker Infrastructure ---
+
+
+class DeliveryStatus(StrEnum):
+    """Vocabulary for the ``deliveries.status`` column.
+
+    Enumerates the lifecycle states a delivery row can hold. Members are
+    plain strings so they compare and persist identically to the bare
+    literals previously used, while giving the type checker a bounded,
+    named set (bounded-cardinality metric labels rely on this too).
+    """
+
+    PENDING = "pending"
+    CLAIMED = "claimed"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+    SKIPPED = "skipped"
 
 
 class WorkerConfig(BaseModel):
@@ -126,11 +142,18 @@ class Delivery:
 
     Workers iterate over Delivery objects so they can mark each
     delivery by its own row ID rather than the event's ID.
+
+    Attributes:
+        trace_context: Opaque W3C ``traceparent`` of the operation that
+            originally appended the event, or None for non-instrumented
+            contexts (CLI/cron). Domain code never parses this — it is
+            carried through so infrastructure can link dispatch spans.
     """
 
     id: str
     event: "Event"
     retry_count: int = 0
+    trace_context: str | None = None
 
 
 @dataclass(frozen=True)

--- a/server/osa/domain/shared/failure.py
+++ b/server/osa/domain/shared/failure.py
@@ -23,7 +23,7 @@ These exceptions drive worker retry policy, not HTTP responses, so
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import assert_never
+from typing import ClassVar, assert_never
 
 from osa.domain.shared.error import OSAError
 
@@ -70,6 +70,20 @@ class RuntimeFailure(OSAError):
         self.oom_retries = oom_retries
 
 
+class DecisionKind(StrEnum):
+    """Bounded label vocabulary for the decision a :class:`FailurePolicy` picks.
+
+    A metric-friendly projection of the :data:`Decision` union: one member per
+    Decision variant. Keeps failure/decision metric labels algebraic (bounded
+    cardinality) instead of stringly-typed at emission sites.
+    """
+
+    RETRY = "retry"
+    RETRY_WITH_MORE_MEMORY = "retry_with_more_memory"
+    GIVE_UP = "give_up"
+    ABORT_RUN = "abort_run"
+
+
 @dataclass(frozen=True)
 class PriorAttempts:
     """Remediation state the policy consults — a view over existing data.
@@ -85,10 +99,14 @@ class PriorAttempts:
 class Retry:
     """Re-drive the failed unit of work; the worker's delivery budget bounds it."""
 
+    kind_label: ClassVar[DecisionKind] = DecisionKind.RETRY
+
 
 @dataclass(frozen=True)
 class RetryWithMoreMemory:
     """Re-run with a doubled memory limit — the only adjust-and-rerun today."""
+
+    kind_label: ClassVar[DecisionKind] = DecisionKind.RETRY_WITH_MORE_MEMORY
 
 
 @dataclass(frozen=True)
@@ -98,6 +116,8 @@ class GiveUp:
     reason: str
     kind: FailureKind
 
+    kind_label: ClassVar[DecisionKind] = DecisionKind.GIVE_UP
+
 
 @dataclass(frozen=True)
 class AbortRun:
@@ -105,6 +125,8 @@ class AbortRun:
 
     reason: str
     kind: FailureKind
+
+    kind_label: ClassVar[DecisionKind] = DecisionKind.ABORT_RUN
 
 
 Decision = Retry | RetryWithMoreMemory | GiveUp | AbortRun

--- a/server/osa/domain/shared/port/event_repository.py
+++ b/server/osa/domain/shared/port/event_repository.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Protocol, TypeVar
 
-from osa.domain.shared.event import ClaimResult, Event, EventId
+from osa.domain.shared.event import ClaimResult, DeliveryStats, Event, EventId
 
 E = TypeVar("E", bound=Event)
 
@@ -118,6 +118,17 @@ class EventRepository(Protocol):
 
         Returns:
             Number of deliveries reset.
+        """
+        ...
+
+    async def delivery_stats(self) -> DeliveryStats:
+        """Aggregate delivery counts by (consumer_group, status) and the oldest eligible pending event time.
+
+        Returns:
+            A DeliveryStats snapshot: per-``(consumer_group, status)`` row
+            counts, and the ``events.created_at`` of the oldest *eligible*
+            pending delivery (``deliver_after`` NULL or already elapsed), or
+            None when nothing is currently claimable.
         """
         ...
 

--- a/server/osa/domain/shared/port/instrumentation.py
+++ b/server/osa/domain/shared/port/instrumentation.py
@@ -1,0 +1,29 @@
+"""OutboxInstrumentation port — a domain-probe for outbox-delivery telemetry.
+
+One method per business fact worth measuring (a delivery reached a terminal
+disposition). Consumed by the infrastructure worker and implemented by an OTel
+adapter; trivially no-op-able in tests. Synchronous (emission must never block
+dispatch) and keyword-only. Labels are typed enums so cardinality stays bounded.
+"""
+
+from abc import abstractmethod
+from typing import Protocol
+
+from osa.domain.shared.event import DeliveryStatus
+from osa.domain.shared.port import Port
+
+
+class OutboxInstrumentation(Port, Protocol):
+    """Domain-probe for outbox-delivery metrics (see module docstring)."""
+
+    @abstractmethod
+    def delivery_completed(
+        self,
+        *,
+        consumer_group: str,
+        status: DeliveryStatus,
+        retry_count: int,
+        duration_s: float,
+    ) -> None:
+        """Record a delivery reaching a terminal disposition after dispatch."""
+        ...

--- a/server/osa/domain/validation/port/instrumentation.py
+++ b/server/osa/domain/validation/port/instrumentation.py
@@ -1,0 +1,35 @@
+"""HookInstrumentation port — a domain-probe for hook-execution telemetry.
+
+One method per business fact worth measuring (a run finished; a failure was
+decided). Implemented by infrastructure (an OTel adapter); trivially no-op-able
+in tests. All methods are synchronous — metric emission must never block the
+execution path — and keyword-only so call sites read as named facts, not
+positional tuples. Labels are typed value objects / enums so metric cardinality
+stays bounded and stringly-typed labels never leak into domain code.
+"""
+
+from abc import abstractmethod
+from typing import Protocol
+
+from osa.domain.shared.failure import DecisionKind, FailureKind
+from osa.domain.shared.model.hook import HookName
+from osa.domain.shared.port import Port
+from osa.domain.validation.model.hook_run import HookRunStatus
+
+
+class HookInstrumentation(Port, Protocol):
+    """Domain-probe for hook-execution metrics (see module docstring)."""
+
+    @abstractmethod
+    def run_finished(
+        self, *, hook: HookName, status: HookRunStatus, duration_s: float, oom_retries: int
+    ) -> None:
+        """Record that one hook execution completed with a terminal status."""
+        ...
+
+    @abstractmethod
+    def run_failure_decided(
+        self, *, hook: HookName, kind: FailureKind, decision: DecisionKind
+    ) -> None:
+        """Record the policy decision taken for one observed hook failure."""
+        ...

--- a/server/osa/infrastructure/event/di.py
+++ b/server/osa/infrastructure/event/di.py
@@ -22,6 +22,7 @@ from osa.domain.shared.outbox import Outbox
 from osa.domain.shared.port.event_repository import EventRepository
 from osa.domain.validation.handler import ValidateDeposition
 from osa.infrastructure.event.worker import WorkerPool
+from osa.infrastructure.telemetry.sampler import TelemetrySampler
 from osa.util.di.base import Provider
 from osa.util.di.scope import Scope
 
@@ -135,9 +136,10 @@ class EventProvider(Provider):
         container: AsyncContainer,
         handler_types: HandlerTypes,
         config: Config,
+        sampler: TelemetrySampler,
     ) -> WorkerPool:
         """WorkerPool with pull-based event handlers."""
-        pool = WorkerPool(container=container, stale_claim_interval=60.0)
+        pool = WorkerPool(container=container, stale_claim_interval=60.0, sampler=sampler)
 
         for handler_type in handler_types:
             pool.register(handler_type, config=config)

--- a/server/osa/infrastructure/event/worker.py
+++ b/server/osa/infrastructure/event/worker.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, NewType
 
 if TYPE_CHECKING:
     from osa.config import Config
+    from osa.infrastructure.telemetry.sampler import TelemetrySampler
 
 import logfire
 from apscheduler import AsyncScheduler
@@ -405,12 +406,18 @@ class WorkerPool:
         self,
         container: AsyncContainer | None = None,
         stale_claim_interval: float = 60.0,
+        *,
+        sampler: "TelemetrySampler | None" = None,
+        sampler_interval: float = 15.0,
     ) -> None:
         self._container = container
         self._workers: list[Worker] = []
         self._stale_claim_interval = stale_claim_interval
         self._stale_claim_task: asyncio.Task | None = None
         self._device_auth_cleanup_task: asyncio.Task | None = None
+        self._sampler = sampler
+        self._sampler_interval = sampler_interval
+        self._telemetry_sampler_task: asyncio.Task | None = None
         self._shutdown = False
         self._scheduler: AsyncScheduler | None = None
         self._exit_stack: AsyncExitStack | None = None
@@ -527,6 +534,12 @@ class WorkerPool:
             self._run_device_auth_cleanup(), name="device-auth-cleanup"
         )
 
+        # Start telemetry gauge sampler (only when observability is wired in)
+        if self._sampler is not None:
+            self._telemetry_sampler_task = asyncio.create_task(
+                self._run_telemetry_sampler(), name="telemetry-sampler"
+            )
+
         logger.info(
             f"WorkerPool started with {len(self._workers)} workers, {len(schedules)} schedules"
         )
@@ -553,6 +566,13 @@ class WorkerPool:
             self._device_auth_cleanup_task.cancel()
             try:
                 await self._device_auth_cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._telemetry_sampler_task and not self._telemetry_sampler_task.done():
+            self._telemetry_sampler_task.cancel()
+            try:
+                await self._telemetry_sampler_task
             except asyncio.CancelledError:
                 pass
 
@@ -625,6 +645,28 @@ class WorkerPool:
                 break
             except Exception as e:
                 logger.error(f"Stale claim cleanup failed: {e}")
+
+    async def _run_telemetry_sampler(self) -> None:
+        """Periodically refresh the telemetry gauge snapshot.
+
+        Mirrors :meth:`_run_stale_claim_cleanup`'s shutdown discipline. The
+        sampler itself never raises (it warns and keeps the last snapshot), but
+        the broad-except guard keeps the loop alive against any unexpected
+        failure so gauges merely go stale rather than the loop dying.
+        """
+        while not self._shutdown:
+            try:
+                await asyncio.sleep(self._sampler_interval)
+
+                if self._shutdown or self._container is None or self._sampler is None:
+                    break
+
+                await self._sampler.refresh(self._container, self._workers)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warn(f"Telemetry sampler loop error: {e}")
 
     async def _run_device_auth_cleanup(self) -> None:
         """Periodically delete expired device authorizations."""

--- a/server/osa/infrastructure/event/worker.py
+++ b/server/osa/infrastructure/event/worker.py
@@ -117,6 +117,16 @@ class Worker:
         """Current worker state."""
         return self._state
 
+    @property
+    def is_alive(self) -> bool:
+        """True when the worker's background task is running (started, not done).
+
+        Distinguishes a started-and-healthy worker from an un-started one (task
+        is None) or a crashed one (task finished). Consumed by the ``/ready``
+        readiness check.
+        """
+        return self._task is not None and not self._task.done()
+
     def set_container(self, container: AsyncContainer) -> None:
         """Set the DI container for scoped dependency resolution."""
         self._container = container

--- a/server/osa/infrastructure/event/worker.py
+++ b/server/osa/infrastructure/event/worker.py
@@ -1,6 +1,7 @@
 """Worker and WorkerPool for pull-based event processing."""
 
 import asyncio
+import time
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -9,12 +10,18 @@ from typing import TYPE_CHECKING, Any, NewType
 if TYPE_CHECKING:
     from osa.config import Config
 
+import logfire
 from apscheduler import AsyncScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dishka import AsyncContainer
+from opentelemetry import trace as otel_trace
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from osa.domain.auth.model.identity import Identity, System
 from osa.domain.shared.error import PermanentError, SkippedEvents, TransientError
 from osa.domain.shared.event import (
+    Delivery,
+    DeliveryStatus,
     EventHandler,
     Schedule,
     WorkerConfig,
@@ -22,10 +29,15 @@ from osa.domain.shared.event import (
     WorkerStatus,
 )
 from osa.domain.shared.outbox import Outbox
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation
 from osa.infrastructure.logging import get_logger
 from osa.util.di.scope import Scope
 
 logger = get_logger(__name__)
+
+# W3C traceparent extraction only (no baggage). Module-level so the propagator
+# is built once; tests monkeypatch ``logfire.span`` in this module's namespace.
+_PROPAGATOR = TraceContextTextMapPropagator()
 
 
 @dataclass
@@ -113,8 +125,6 @@ class Worker:
         if self._container is None:
             raise RuntimeError("Container not set. Call set_container() first.")
 
-        import logfire
-
         self._shutdown = False
         self._task = asyncio.create_task(self._run(), name=f"worker-{self.name}")
         logfire.info("worker started: {worker_name}", worker_name=self.name)
@@ -143,6 +153,42 @@ class Worker:
         finally:
             logger.info(f"Worker '{self.name}' stopped")
 
+    def _links_from_deliveries(
+        self, deliveries: list[Delivery]
+    ) -> list[tuple[SpanContext, dict[str, str]]]:
+        """Span links back to the operations that appended each claimed event.
+
+        A batch can mix events appended by several unrelated requests, so the
+        dispatch span *links* to each origin span (many-to-one) rather than
+        adopting a single parent. A missing or malformed traceparent must never
+        affect dispatch — it only costs one link.
+        """
+        links: list[tuple[SpanContext, dict[str, str]]] = []
+        for d in deliveries:
+            if d.trace_context is None:
+                # Non-instrumented origin (CLI/cron) — nothing to link, silently.
+                continue
+            try:
+                ctx = _PROPAGATOR.extract({"traceparent": d.trace_context})
+                sc = otel_trace.get_current_span(ctx).get_span_context()
+                if not sc.is_valid:
+                    logger.warn(
+                        "Worker '{name}' ignoring malformed traceparent on delivery {id}",
+                        name=self.name,
+                        id=d.id,
+                    )
+                    continue
+                links.append((sc, {"delivery.id": d.id}))
+            except Exception as exc:
+                # A bad traceparent must NEVER break dispatch — warn and skip.
+                logger.warn(
+                    "Worker '{name}' failed to extract trace link for delivery {id}: {error}",
+                    name=self.name,
+                    id=d.id,
+                    error=str(exc),
+                )
+        return links
+
     async def _poll_once(self) -> bool:
         """Execute one poll cycle: claim deliveries, process, mark status.
 
@@ -156,6 +202,8 @@ class Worker:
 
         async with self._container(scope=Scope.UOW, context={Identity: System()}) as scope:
             outbox = await scope.get(Outbox)
+            # APP-scoped instrument, resolvable from this child UOW scope.
+            instrumentation = await scope.get(OutboxInstrumentation)
 
             # Claim deliveries for this consumer group
             result = await outbox.claim(
@@ -172,43 +220,124 @@ class Worker:
             self._state.current_batch = result.events
             self._state.last_claim_at = result.claimed_at
 
-            handler = await scope.get(self._handler_type)
+            # Link the dispatch span back to every origin span in the batch so
+            # request → RunHooks → PublishBatch → … chains reconnect across the
+            # outbox. The span is current while ``handle`` runs, so handler-internal
+            # spans nest under it and events appended during handling capture it as
+            # their traceparent (the next hop links back here).
+            links = self._links_from_deliveries(result.deliveries)
+            dispatch_start = time.monotonic()
 
-            try:
-                events = result.events
+            with logfire.span(
+                "worker.dispatch {consumer_group}",
+                consumer_group=self._consumer_group,
+                batch_size=len(result.deliveries),
+                _links=links,
+            ):
+                handler = await scope.get(self._handler_type)
 
-                if self._batch_size > 1:
-                    await handler.handle_batch(events)
-                else:
-                    await handler.handle(events[0])
+                try:
+                    events = result.events
 
-                # Mark all deliveries as delivered
-                for delivery in result.deliveries:
-                    await outbox.mark_delivered(delivery.id)
-
-                self._state.processed_count += len(result.deliveries)
-
-            except SkippedEvents as e:
-                logger.warn(f"Worker '{self.name}' skipping {len(e.event_ids)} events: {e.reason}")
-                skipped_set = set(e.event_ids)
-                for delivery in result.deliveries:
-                    if delivery.event.id in skipped_set:
-                        await outbox.mark_skipped(delivery.id, e.reason)
+                    if self._batch_size > 1:
+                        await handler.handle_batch(events)
                     else:
+                        await handler.handle(events[0])
+
+                    # Mark all deliveries as delivered
+                    for delivery in result.deliveries:
                         await outbox.mark_delivered(delivery.id)
-                self._state.processed_count += len(result.deliveries) - len(e.event_ids)
 
-            except TransientError as e:
-                self._state.failed_count += len(result.deliveries)
-                self._state.error = e
-                for delivery in result.deliveries:
-                    exhausted = delivery.retry_count + 1 >= self._max_retries
-                    if exhausted:
-                        logger.warn(
-                            "Worker '{name}' transient retries exhausted: {error}",
-                            name=self.name,
-                            error=str(e),
+                    self._state.processed_count += len(result.deliveries)
+
+                    elapsed = time.monotonic() - dispatch_start
+                    for delivery in result.deliveries:
+                        instrumentation.delivery_completed(
+                            consumer_group=self._consumer_group,
+                            status=DeliveryStatus.DELIVERED,
+                            retry_count=delivery.retry_count,
+                            duration_s=elapsed,
                         )
+
+                except SkippedEvents as e:
+                    logger.warn(
+                        f"Worker '{self.name}' skipping {len(e.event_ids)} events: {e.reason}"
+                    )
+                    skipped_set = set(e.event_ids)
+                    elapsed = time.monotonic() - dispatch_start
+                    for delivery in result.deliveries:
+                        if delivery.event.id in skipped_set:
+                            await outbox.mark_skipped(delivery.id, e.reason)
+                            status = DeliveryStatus.SKIPPED
+                        else:
+                            await outbox.mark_delivered(delivery.id)
+                            status = DeliveryStatus.DELIVERED
+                        instrumentation.delivery_completed(
+                            consumer_group=self._consumer_group,
+                            status=status,
+                            retry_count=delivery.retry_count,
+                            duration_s=elapsed,
+                        )
+                    self._state.processed_count += len(result.deliveries) - len(e.event_ids)
+
+                except TransientError as e:
+                    self._state.failed_count += len(result.deliveries)
+                    self._state.error = e
+                    elapsed = time.monotonic() - dispatch_start
+                    for delivery in result.deliveries:
+                        exhausted = delivery.retry_count + 1 >= self._max_retries
+                        if exhausted:
+                            logger.warn(
+                                "Worker '{name}' transient retries exhausted: {error}",
+                                name=self.name,
+                                error=str(e),
+                            )
+                            try:
+                                await handler.on_exhausted(delivery.event)
+                            except Exception as exhausted_err:
+                                logger.error(
+                                    "Worker '{name}' on_exhausted failed: {error}",
+                                    name=self.name,
+                                    error=str(exhausted_err),
+                                )
+                            await outbox.mark_failed(delivery.id, str(e))
+                        else:
+                            backoff_seconds = min(300, 60 * (2**delivery.retry_count))
+                            deliver_after = datetime.now(UTC) + timedelta(seconds=backoff_seconds)
+                            logger.warn(
+                                "Worker '{name}' transient failure: {error} "
+                                "(attempt={attempt}, next_retry=+{backoff}s)",
+                                name=self.name,
+                                error=str(e),
+                                attempt=delivery.retry_count,
+                                backoff=backoff_seconds,
+                            )
+                            await outbox.mark_failed_with_retry(
+                                delivery.id,
+                                str(e),
+                                max_retries=self._max_retries,
+                                deliver_after=deliver_after,
+                            )
+                        # The counter measures dispatch ATTEMPT outcomes: a
+                        # retry-scheduled delivery is a failed attempt even though
+                        # its row returns to pending for a later re-drive.
+                        instrumentation.delivery_completed(
+                            consumer_group=self._consumer_group,
+                            status=DeliveryStatus.FAILED,
+                            retry_count=delivery.retry_count,
+                            duration_s=elapsed,
+                        )
+
+                except PermanentError as e:
+                    self._state.failed_count += len(result.deliveries)
+                    self._state.error = e
+                    logger.error(
+                        "Worker '{name}' permanent failure: {error}",
+                        name=self.name,
+                        error=str(e),
+                    )
+                    elapsed = time.monotonic() - dispatch_start
+                    for delivery in result.deliveries:
                         try:
                             await handler.on_exhausted(delivery.event)
                         except Exception as exhausted_err:
@@ -218,76 +347,53 @@ class Worker:
                                 error=str(exhausted_err),
                             )
                         await outbox.mark_failed(delivery.id, str(e))
-                    else:
-                        backoff_seconds = min(300, 60 * (2**delivery.retry_count))
-                        deliver_after = datetime.now(UTC) + timedelta(seconds=backoff_seconds)
-                        logger.warn(
-                            "Worker '{name}' transient failure: {error} "
-                            "(attempt={attempt}, next_retry=+{backoff}s)",
-                            name=self.name,
-                            error=str(e),
-                            attempt=delivery.retry_count,
-                            backoff=backoff_seconds,
-                        )
-                        await outbox.mark_failed_with_retry(
-                            delivery.id,
-                            str(e),
-                            max_retries=self._max_retries,
-                            deliver_after=deliver_after,
+                        instrumentation.delivery_completed(
+                            consumer_group=self._consumer_group,
+                            status=DeliveryStatus.FAILED,
+                            retry_count=delivery.retry_count,
+                            duration_s=elapsed,
                         )
 
-            except PermanentError as e:
-                self._state.failed_count += len(result.deliveries)
-                self._state.error = e
-                logger.error(
-                    "Worker '{name}' permanent failure: {error}",
-                    name=self.name,
-                    error=str(e),
-                )
-                for delivery in result.deliveries:
-                    try:
-                        await handler.on_exhausted(delivery.event)
-                    except Exception as exhausted_err:
-                        logger.error(
-                            "Worker '{name}' on_exhausted failed: {error}",
-                            name=self.name,
-                            error=str(exhausted_err),
-                        )
-                    await outbox.mark_failed(delivery.id, str(e))
-
-            except Exception as e:
-                self._state.failed_count += len(result.deliveries)
-                self._state.error = e
-                logger.error(
-                    "Worker '{name}' batch failed: {error}",
-                    name=self.name,
-                    error=str(e),
-                )
-                for delivery in result.deliveries:
-                    exhausted = delivery.retry_count + 1 >= self._max_retries
-                    if exhausted:
-                        try:
-                            await handler.on_exhausted(delivery.event)
-                        except Exception as exhausted_err:
-                            logger.error(
-                                "Worker '{name}' on_exhausted failed: {error}",
-                                name=self.name,
-                                error=str(exhausted_err),
+                except Exception as e:
+                    self._state.failed_count += len(result.deliveries)
+                    self._state.error = e
+                    logger.error(
+                        "Worker '{name}' batch failed: {error}",
+                        name=self.name,
+                        error=str(e),
+                    )
+                    elapsed = time.monotonic() - dispatch_start
+                    for delivery in result.deliveries:
+                        exhausted = delivery.retry_count + 1 >= self._max_retries
+                        if exhausted:
+                            try:
+                                await handler.on_exhausted(delivery.event)
+                            except Exception as exhausted_err:
+                                logger.error(
+                                    "Worker '{name}' on_exhausted failed: {error}",
+                                    name=self.name,
+                                    error=str(exhausted_err),
+                                )
+                            await outbox.mark_failed(delivery.id, str(e))
+                        else:
+                            backoff_seconds = min(30, 5 ** (delivery.retry_count + 1))
+                            deliver_after = datetime.now(UTC) + timedelta(seconds=backoff_seconds)
+                            await outbox.mark_failed_with_retry(
+                                delivery.id,
+                                str(e),
+                                max_retries=self._max_retries,
+                                deliver_after=deliver_after,
                             )
-                        await outbox.mark_failed(delivery.id, str(e))
-                    else:
-                        backoff_seconds = min(30, 5 ** (delivery.retry_count + 1))
-                        deliver_after = datetime.now(UTC) + timedelta(seconds=backoff_seconds)
-                        await outbox.mark_failed_with_retry(
-                            delivery.id,
-                            str(e),
-                            max_retries=self._max_retries,
-                            deliver_after=deliver_after,
+                        instrumentation.delivery_completed(
+                            consumer_group=self._consumer_group,
+                            status=DeliveryStatus.FAILED,
+                            retry_count=delivery.retry_count,
+                            duration_s=elapsed,
                         )
 
-            finally:
-                self._state.current_batch = []
-                self._state.status = WorkerStatus.IDLE
+                finally:
+                    self._state.current_batch = []
+                    self._state.status = WorkerStatus.IDLE
 
         return True
 

--- a/server/osa/infrastructure/ingest/di.py
+++ b/server/osa/infrastructure/ingest/di.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from osa.config import Config
 from osa.domain.deposition.service.convention import ConventionService
 from osa.domain.ingest.command.start_ingest import StartIngestHandler
+from osa.domain.ingest.port.instrumentation import IngestInstrumentation
 from osa.domain.ingest.query.get_ingestion import GetIngestionHandler
 from osa.infrastructure.s3.client import S3Client
 from osa.domain.ingest.port.repository import IngestRunRepository
@@ -40,12 +41,14 @@ class IngestProvider(Provider):
         convention_service: ConventionService,
         outbox: Outbox,
         node_domain: Domain,
+        instrumentation: IngestInstrumentation,
     ) -> IngestService:
         return IngestService(
             ingest_repo=ingest_repo,
             convention_service=convention_service,
             outbox=outbox,
             node_domain=node_domain,
+            instrumentation=instrumentation,
         )
 
     # Ingest storage — default (filesystem, for local/Docker)

--- a/server/osa/infrastructure/persistence/repository/event.py
+++ b/server/osa/infrastructure/persistence/repository/event.py
@@ -5,17 +5,20 @@ from datetime import UTC, datetime, timedelta
 from typing import TypeVar
 from uuid import uuid4
 
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sqlalchemy import CursorResult, func, insert, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from osa.domain.shared.error import InfrastructureError
-from osa.domain.shared.event import ClaimResult, Delivery, Event, EventId
+from osa.domain.shared.event import ClaimResult, Delivery, DeliveryStatus, Event, EventId
 from osa.domain.shared.port.event_repository import EventRepository
 from osa.infrastructure.persistence.tables import deliveries_table, events_table
 
 logger = logging.getLogger(__name__)
 
 E = TypeVar("E", bound=Event)
+
+_PROPAGATOR = TraceContextTextMapPropagator()
 
 
 class SQLAlchemyEventRepository(EventRepository):
@@ -27,6 +30,20 @@ class SQLAlchemyEventRepository(EventRepository):
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    @staticmethod
+    def _capture_traceparent() -> str | None:
+        """Serialize the current span context as a W3C ``traceparent``.
+
+        Returns the traceparent of the operation that is appending the
+        event, or None for non-instrumented contexts (CLI/cron, or any
+        code path without an active recording+sampled span). The value is
+        opaque and stored verbatim on the events row so worker dispatch
+        spans can later link back to the originating operation.
+        """
+        carrier: dict[str, str] = {}
+        _PROPAGATOR.inject(carrier)  # implicit current context
+        return carrier.get("traceparent")  # None when no active recording span
 
     async def save_with_deliveries(
         self,
@@ -43,6 +60,7 @@ class SQLAlchemyEventRepository(EventRepository):
             event_type=type(event).__name__,
             payload=event.model_dump(mode="json"),
             created_at=now,
+            trace_context=self._capture_traceparent(),
         )
         await self._session.execute(event_stmt)
 
@@ -52,7 +70,7 @@ class SQLAlchemyEventRepository(EventRepository):
                 id=str(uuid4()),
                 event_id=str(event.id),
                 consumer_group=group,
-                status="pending",
+                status=DeliveryStatus.PENDING.value,
                 retry_count=0,
                 deliver_after=deliver_after,
                 updated_at=now,
@@ -199,11 +217,12 @@ class SQLAlchemyEventRepository(EventRepository):
                 deliveries_table.c.retry_count,
                 events_table.c.event_type,
                 events_table.c.payload,
+                events_table.c.trace_context,
             )
             .join(events_table, deliveries_table.c.event_id == events_table.c.id)
             .where(
                 deliveries_table.c.consumer_group == consumer_group,
-                deliveries_table.c.status == "pending",
+                deliveries_table.c.status == DeliveryStatus.PENDING.value,
                 events_table.c.event_type.in_(event_types),
                 deliver_after_eligible,
             )
@@ -223,17 +242,24 @@ class SQLAlchemyEventRepository(EventRepository):
         update_stmt = (
             update(deliveries_table)
             .where(deliveries_table.c.id.in_(delivery_ids))
-            .values(status="claimed", claimed_at=now, updated_at=now)
+            .values(status=DeliveryStatus.CLAIMED.value, claimed_at=now, updated_at=now)
         )
         await self._session.execute(update_stmt)
 
         # Deserialize events and wrap in Delivery envelopes
         deliveries: list[Delivery] = []
         for row in rows:
-            delivery_id, retry_count, event_type, payload = row
+            delivery_id, retry_count, event_type, payload, trace_context = row
             event = self._deserialize(event_type, payload)
             if event is not None:
-                deliveries.append(Delivery(id=delivery_id, event=event, retry_count=retry_count))
+                deliveries.append(
+                    Delivery(
+                        id=delivery_id,
+                        event=event,
+                        retry_count=retry_count,
+                        trace_context=trace_context,
+                    )
+                )
 
         return ClaimResult(deliveries=deliveries, claimed_at=now)
 
@@ -249,7 +275,7 @@ class SQLAlchemyEventRepository(EventRepository):
             "status": status,
             "updated_at": now,
         }
-        if status == "delivered":
+        if status == DeliveryStatus.DELIVERED.value:
             values["delivered_at"] = now
         if error is not None:
             values["delivery_error"] = error
@@ -264,11 +290,11 @@ class SQLAlchemyEventRepository(EventRepository):
         stmt = (
             update(deliveries_table)
             .where(
-                deliveries_table.c.status == "claimed",
+                deliveries_table.c.status == DeliveryStatus.CLAIMED.value,
                 deliveries_table.c.claimed_at < cutoff,
             )
             .values(
-                status="pending",
+                status=DeliveryStatus.PENDING.value,
                 claimed_at=None,
                 updated_at=datetime.now(UTC),
             )
@@ -317,7 +343,7 @@ class SQLAlchemyEventRepository(EventRepository):
                 update(deliveries_table)
                 .where(deliveries_table.c.id == delivery_id)
                 .values(
-                    status="failed",
+                    status=DeliveryStatus.FAILED.value,
                     delivery_error=error,
                     retry_count=new_retry_count,
                     deliver_after=None,
@@ -331,7 +357,7 @@ class SQLAlchemyEventRepository(EventRepository):
                 update(deliveries_table)
                 .where(deliveries_table.c.id == delivery_id)
                 .values(
-                    status="pending",
+                    status=DeliveryStatus.PENDING.value,
                     delivery_error=error,
                     retry_count=new_retry_count,
                     deliver_after=deliver_after,

--- a/server/osa/infrastructure/persistence/repository/event.py
+++ b/server/osa/infrastructure/persistence/repository/event.py
@@ -10,7 +10,14 @@ from sqlalchemy import CursorResult, func, insert, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from osa.domain.shared.error import InfrastructureError
-from osa.domain.shared.event import ClaimResult, Delivery, DeliveryStatus, Event, EventId
+from osa.domain.shared.event import (
+    ClaimResult,
+    Delivery,
+    DeliveryStats,
+    DeliveryStatus,
+    Event,
+    EventId,
+)
 from osa.domain.shared.port.event_repository import EventRepository
 from osa.infrastructure.persistence.tables import deliveries_table, events_table
 
@@ -307,6 +314,57 @@ class SQLAlchemyEventRepository(EventRepository):
         if count > 0:
             logger.info(f"Reset {count} stale deliveries (older than {timeout_seconds}s)")
         return count
+
+    async def delivery_stats(self) -> DeliveryStats:
+        """Aggregate delivery counts and the oldest eligible pending event time.
+
+        Two index-friendly queries:
+        1. ``GROUP BY consumer_group, status`` over ``deliveries`` for the
+           per-pair counts (covered by ``idx_deliveries_claim``).
+        2. ``min(events.created_at)`` over pending deliveries whose
+           ``deliver_after`` is NULL or already elapsed — the oldest work a
+           worker could claim right now.
+        """
+        counts: dict[tuple[str, DeliveryStatus], int] = {}
+        count_stmt = select(
+            deliveries_table.c.consumer_group,
+            deliveries_table.c.status,
+            func.count(),
+        ).group_by(deliveries_table.c.consumer_group, deliveries_table.c.status)
+        result = await self._session.execute(count_stmt)
+        for consumer_group, status, row_count in result.all():
+            try:
+                delivery_status = DeliveryStatus(status)
+            except ValueError:
+                logger.warning(
+                    f"Unknown delivery status '{status}' for group '{consumer_group}' - skipping"
+                )
+                continue
+            counts[(consumer_group, delivery_status)] = row_count
+
+        eligible_pending = or_(
+            deliveries_table.c.deliver_after.is_(None),
+            deliveries_table.c.deliver_after <= func.now(),
+        )
+        oldest_stmt = (
+            select(func.min(events_table.c.created_at))
+            .select_from(
+                deliveries_table.join(
+                    events_table, deliveries_table.c.event_id == events_table.c.id
+                )
+            )
+            .where(
+                deliveries_table.c.status == DeliveryStatus.PENDING.value,
+                eligible_pending,
+            )
+        )
+        oldest = (await self._session.execute(oldest_stmt)).scalar()
+        # SQLite (unit tests) returns naive datetimes from timezone-aware
+        # columns; normalize so the return type is consistently UTC-aware.
+        if oldest is not None and oldest.tzinfo is None:
+            oldest = oldest.replace(tzinfo=UTC)
+
+        return DeliveryStats(counts=counts, oldest_pending_created_at=oldest)
 
     async def mark_failed_with_retry(
         self,

--- a/server/osa/infrastructure/persistence/tables.py
+++ b/server/osa/infrastructure/persistence/tables.py
@@ -106,6 +106,7 @@ events_table = Table(
     Column("event_type", String(128), nullable=False),
     Column("payload", JSON, nullable=False),
     Column("created_at", DateTime(timezone=True), nullable=False),
+    Column("trace_context", String, nullable=True),
 )
 
 Index(

--- a/server/osa/infrastructure/telemetry/__init__.py
+++ b/server/osa/infrastructure/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Telemetry infrastructure: bootstrap, instrumentation adapters, and DI wiring."""

--- a/server/osa/infrastructure/telemetry/api.py
+++ b/server/osa/infrastructure/telemetry/api.py
@@ -1,0 +1,22 @@
+"""OTel adapter for API-edge telemetry.
+
+Infrastructure-only (no domain port): the API layer is itself infrastructure, so
+there is no domain fact to abstract. Owns ``osa_unhandled_errors_total``,
+incremented by the app's bare-``Exception`` handler.
+"""
+
+from opentelemetry.metrics import Meter
+
+
+class ApiInstrumentation:
+    """Emits API-edge metrics through an injected OTel :class:`Meter`."""
+
+    def __init__(self, meter: Meter) -> None:
+        self._unhandled_errors = meter.create_counter(
+            "osa_unhandled_errors_total",
+            description="Count of unhandled exceptions surfaced to the global error handler.",
+        )
+
+    def unhandled_error(self) -> None:
+        """Record one unhandled exception reaching the global error handler."""
+        self._unhandled_errors.add(1)

--- a/server/osa/infrastructure/telemetry/di.py
+++ b/server/osa/infrastructure/telemetry/di.py
@@ -8,6 +8,7 @@ shares one set of instruments. Trace sampling is configured process-wide in
 
 from dishka import provide
 from opentelemetry.metrics import Meter, get_meter_provider
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from osa.domain.ingest.port.instrumentation import IngestInstrumentation
 from osa.domain.shared.port.instrumentation import OutboxInstrumentation
@@ -16,6 +17,7 @@ from osa.infrastructure.telemetry.api import ApiInstrumentation
 from osa.infrastructure.telemetry.hook import OtelHookInstrumentation
 from osa.infrastructure.telemetry.ingest import OtelIngestInstrumentation
 from osa.infrastructure.telemetry.outbox import OtelOutboxInstrumentation
+from osa.infrastructure.telemetry.sampler import TelemetrySampler
 from osa.util.di.base import Provider
 from osa.util.di.scope import Scope
 
@@ -27,6 +29,15 @@ class TelemetryProvider(Provider):
     def get_meter(self) -> Meter:
         """The application meter, from logfire's configured global MeterProvider."""
         return get_meter_provider().get_meter("osa")
+
+    @provide(scope=Scope.APP)
+    def get_sampler(self, meter: Meter, engine: AsyncEngine) -> TelemetrySampler:
+        """The periodic gauge sampler (registers observable gauges on construction).
+
+        ``AsyncEngine`` is provided APP-scoped by ``PersistenceProvider``; the
+        WorkerPool drives :meth:`TelemetrySampler.refresh` on its loop.
+        """
+        return TelemetrySampler(meter, engine)
 
     hook = provide(OtelHookInstrumentation, scope=Scope.APP, provides=HookInstrumentation)
     ingest = provide(OtelIngestInstrumentation, scope=Scope.APP, provides=IngestInstrumentation)

--- a/server/osa/infrastructure/telemetry/di.py
+++ b/server/osa/infrastructure/telemetry/di.py
@@ -1,0 +1,34 @@
+"""Dependency-injection provider for telemetry instrumentation.
+
+Binds the OTel meter (resolved from logfire's configured global MeterProvider)
+and each instrumentation adapter as an APP-scoped singleton, so every service
+shares one set of instruments. Trace sampling is configured process-wide in
+:mod:`osa.infrastructure.telemetry.setup`, not here.
+"""
+
+from dishka import provide
+from opentelemetry.metrics import Meter, get_meter_provider
+
+from osa.domain.ingest.port.instrumentation import IngestInstrumentation
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation
+from osa.domain.validation.port.instrumentation import HookInstrumentation
+from osa.infrastructure.telemetry.api import ApiInstrumentation
+from osa.infrastructure.telemetry.hook import OtelHookInstrumentation
+from osa.infrastructure.telemetry.ingest import OtelIngestInstrumentation
+from osa.infrastructure.telemetry.outbox import OtelOutboxInstrumentation
+from osa.util.di.base import Provider
+from osa.util.di.scope import Scope
+
+
+class TelemetryProvider(Provider):
+    """Provides the OTel meter and instrumentation adapters (all APP-scoped)."""
+
+    @provide(scope=Scope.APP)
+    def get_meter(self) -> Meter:
+        """The application meter, from logfire's configured global MeterProvider."""
+        return get_meter_provider().get_meter("osa")
+
+    hook = provide(OtelHookInstrumentation, scope=Scope.APP, provides=HookInstrumentation)
+    ingest = provide(OtelIngestInstrumentation, scope=Scope.APP, provides=IngestInstrumentation)
+    outbox = provide(OtelOutboxInstrumentation, scope=Scope.APP, provides=OutboxInstrumentation)
+    api = provide(ApiInstrumentation, scope=Scope.APP)

--- a/server/osa/infrastructure/telemetry/hook.py
+++ b/server/osa/infrastructure/telemetry/hook.py
@@ -1,0 +1,53 @@
+"""OTel adapter implementing :class:`HookInstrumentation`.
+
+Owns the ``osa_hook_*`` metric family — no other class emits these names. Label
+values are drawn only from bounded value objects / enums (``HookName.root`` and
+``StrEnum.value``) so time-series cardinality stays finite.
+"""
+
+from opentelemetry.metrics import Meter
+
+from osa.domain.shared.failure import DecisionKind, FailureKind
+from osa.domain.shared.model.hook import HookName
+from osa.domain.validation.model.hook_run import HookRunStatus
+from osa.domain.validation.port.instrumentation import HookInstrumentation
+
+
+class OtelHookInstrumentation(HookInstrumentation):
+    """Emits hook-execution metrics through an injected OTel :class:`Meter`."""
+
+    def __init__(self, meter: Meter) -> None:
+        self._runs = meter.create_counter(
+            "osa_hook_runs_total",
+            description="Count of completed hook executions, by hook and terminal status.",
+        )
+        self._duration = meter.create_histogram(
+            "osa_hook_run_duration_seconds",
+            unit="s",
+            description="Wall-clock duration of hook executions, by hook and status.",
+        )
+        self._failures = meter.create_counter(
+            "osa_hook_failures_total",
+            description="Count of hook failures, by hook, observed cause, and policy decision.",
+        )
+        self._oom_retries = meter.create_counter(
+            "osa_hook_oom_retries_total",
+            description="Count of out-of-memory retries (memory bumps) performed, by hook.",
+        )
+
+    def run_finished(
+        self, *, hook: HookName, status: HookRunStatus, duration_s: float, oom_retries: int
+    ) -> None:
+        attrs = {"hook": hook.root, "status": status.value}
+        self._runs.add(1, attrs)
+        self._duration.record(duration_s, attrs)
+        if oom_retries > 0:
+            self._oom_retries.add(oom_retries, {"hook": hook.root})
+
+    def run_failure_decided(
+        self, *, hook: HookName, kind: FailureKind, decision: DecisionKind
+    ) -> None:
+        self._failures.add(
+            1,
+            {"hook": hook.root, "kind": kind.value, "decision": decision.value},
+        )

--- a/server/osa/infrastructure/telemetry/ingest.py
+++ b/server/osa/infrastructure/telemetry/ingest.py
@@ -1,0 +1,60 @@
+"""OTel adapter implementing :class:`IngestInstrumentation`.
+
+Owns the ``osa_ingest_*`` / ``osa_records_published_total`` metric family. The
+``outcome`` label is drawn from a module-scoped enum (never free strings at the
+call sites) and every other label from a bounded domain enum.
+"""
+
+from enum import StrEnum
+
+from opentelemetry.metrics import Meter
+
+from osa.domain.ingest.model.ingest_run import IngestStatus
+from osa.domain.ingest.port.instrumentation import IngestInstrumentation
+from osa.domain.shared.failure import FailureKind
+
+_NO_KIND = "none"
+
+
+class _BatchOutcome(StrEnum):
+    """Bounded vocabulary for the ``outcome`` label on ``osa_ingest_batches_total``."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class OtelIngestInstrumentation(IngestInstrumentation):
+    """Emits ingest-run metrics through an injected OTel :class:`Meter`."""
+
+    def __init__(self, meter: Meter) -> None:
+        self._batches = meter.create_counter(
+            "osa_ingest_batches_total",
+            description="Count of ingest batches, by outcome (completed / failed).",
+        )
+        self._published = meter.create_counter(
+            "osa_records_published_total",
+            description="Count of records published by completed ingest batches.",
+        )
+        self._runs = meter.create_counter(
+            "osa_ingest_runs_total",
+            description="Count of ingest runs reaching a terminal status, by status and cause.",
+        )
+
+    def batch_completed(self, *, published_count: int) -> None:
+        self._batches.add(1, {"outcome": _BatchOutcome.COMPLETED.value, "kind": _NO_KIND})
+        self._published.add(published_count)
+
+    def batch_failed(self, *, kind: FailureKind | None) -> None:
+        self._batches.add(
+            1,
+            {
+                "outcome": _BatchOutcome.FAILED.value,
+                "kind": kind.value if kind is not None else _NO_KIND,
+            },
+        )
+
+    def run_finished(self, *, status: IngestStatus, kind: FailureKind | None) -> None:
+        self._runs.add(
+            1,
+            {"status": status.value, "kind": kind.value if kind is not None else _NO_KIND},
+        )

--- a/server/osa/infrastructure/telemetry/outbox.py
+++ b/server/osa/infrastructure/telemetry/outbox.py
@@ -1,0 +1,37 @@
+"""OTel adapter implementing :class:`OutboxInstrumentation`.
+
+Owns the ``osa_deliveries_total`` / ``osa_dispatch_duration_seconds`` metrics.
+The ``consumer_group`` label is bounded by the fixed set of registered handlers
+and ``status`` by :class:`DeliveryStatus`.
+"""
+
+from opentelemetry.metrics import Meter
+
+from osa.domain.shared.event import DeliveryStatus
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation
+
+
+class OtelOutboxInstrumentation(OutboxInstrumentation):
+    """Emits outbox-delivery metrics through an injected OTel :class:`Meter`."""
+
+    def __init__(self, meter: Meter) -> None:
+        self._deliveries = meter.create_counter(
+            "osa_deliveries_total",
+            description="Count of terminal outbox deliveries, by consumer group and status.",
+        )
+        self._dispatch = meter.create_histogram(
+            "osa_dispatch_duration_seconds",
+            unit="s",
+            description="Wall-clock dispatch duration of a delivery, by consumer group.",
+        )
+
+    def delivery_completed(
+        self,
+        *,
+        consumer_group: str,
+        status: DeliveryStatus,
+        retry_count: int,
+        duration_s: float,
+    ) -> None:
+        self._deliveries.add(1, {"consumer_group": consumer_group, "status": status.value})
+        self._dispatch.record(duration_s, {"consumer_group": consumer_group})

--- a/server/osa/infrastructure/telemetry/sampler.py
+++ b/server/osa/infrastructure/telemetry/sampler.py
@@ -1,0 +1,218 @@
+"""Periodic telemetry sampler for point-in-time gauges.
+
+Some observability signals are *levels*, not events: outbox lag, per-group
+pending/failed backlog, DB connection-pool occupancy, and live worker counts.
+OpenTelemetry models these as **observable gauges** whose callbacks are invoked
+*synchronously* by the metric reader at collection time. Our sources, however,
+are async (a DB round-trip for delivery stats) and must not run inside a sync
+callback.
+
+:class:`TelemetrySampler` resolves that impedance mismatch: an async loop (owned
+by :class:`~osa.infrastructure.event.worker.WorkerPool`) periodically calls
+:meth:`refresh`, which samples every source and atomically swaps in a fresh
+:class:`SamplerSnapshot`. The gauge callbacks are trivial sync closures that read
+the latest snapshot and yield :class:`~opentelemetry.metrics.Observation` s. A
+stale gauge (from a skipped refresh) is acceptable; a crashed sampler loop is
+not — so :meth:`refresh` never propagates: on any error it warns and keeps the
+previous snapshot.
+"""
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from dishka import AsyncContainer
+from opentelemetry.metrics import CallbackOptions, Meter, Observation
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.pool import QueuePool
+
+from osa.domain.auth.model.identity import Identity, System
+from osa.domain.shared.event import DeliveryStatus, WorkerStatus
+from osa.domain.shared.port.event_repository import EventRepository
+from osa.infrastructure.logging import get_logger
+from osa.util.di.scope import Scope
+
+if TYPE_CHECKING:
+    from osa.infrastructure.event.worker import Worker
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PoolStats:
+    """Point-in-time SQLAlchemy connection-pool occupancy."""
+
+    checked_out: int
+    size: int
+    overflow: int
+
+
+@dataclass(frozen=True)
+class SamplerSnapshot:
+    """Latest sampled values served to OTel gauge callbacks (sync) by the async refresh loop.
+
+    Attributes:
+        outbox_lag_seconds: Age of the oldest *eligible* pending delivery, or
+            ``0.0`` when the queue is empty.
+        pending_by_group: Pending delivery count per consumer group.
+        failed_by_group: Failed delivery count per consumer group.
+        pool: Connection-pool occupancy, or None when the engine has no
+            meaningful pool (SQLite ``StaticPool``).
+        workers_busy: Worker loops currently processing.
+        workers_total: Total worker loops in the pool.
+    """
+
+    outbox_lag_seconds: float = 0.0
+    pending_by_group: Mapping[str, int] = field(default_factory=dict)
+    failed_by_group: Mapping[str, int] = field(default_factory=dict)
+    pool: PoolStats | None = None
+    workers_busy: int = 0
+    workers_total: int = 0
+
+
+class TelemetrySampler:
+    """Bridges async periodic sampling to sync OTel observable-gauge callbacks.
+
+    Owns the ``osa_outbox_*``, ``osa_db_pool_*``, and ``osa_workers_*`` gauges;
+    each name is registered exactly once here. The gauges read from
+    :attr:`_snapshot`, refreshed out-of-band by :meth:`refresh`.
+    """
+
+    def __init__(self, meter: Meter, engine: AsyncEngine) -> None:
+        self._engine = engine
+        self._snapshot = SamplerSnapshot()
+
+        meter.create_observable_gauge(
+            "osa_outbox_lag_seconds",
+            callbacks=[self._observe_lag],
+            unit="s",
+            description="Age of the oldest eligible pending outbox delivery (claimable now).",
+        )
+        meter.create_observable_gauge(
+            "osa_outbox_pending",
+            callbacks=[self._observe_pending],
+            description="Pending (unclaimed) deliveries per consumer group.",
+        )
+        meter.create_observable_gauge(
+            "osa_outbox_failed",
+            callbacks=[self._observe_failed],
+            description="Failed deliveries per consumer group.",
+        )
+        meter.create_observable_gauge(
+            "osa_db_pool_checked_out",
+            callbacks=[self._observe_pool_checked_out],
+            description="Connections currently checked out of the SQLAlchemy pool.",
+        )
+        meter.create_observable_gauge(
+            "osa_db_pool_size",
+            callbacks=[self._observe_pool_size],
+            description="Configured base size of the connection pool.",
+        )
+        meter.create_observable_gauge(
+            "osa_db_pool_overflow",
+            callbacks=[self._observe_pool_overflow],
+            description="Overflow connections open beyond the base pool size.",
+        )
+        meter.create_observable_gauge(
+            "osa_workers_busy",
+            callbacks=[self._observe_workers_busy],
+            description="Worker loops currently processing.",
+        )
+        meter.create_observable_gauge(
+            "osa_workers_total",
+            callbacks=[self._observe_workers_total],
+            description="Total worker loops in the pool.",
+        )
+
+    # ── Gauge callbacks (sync; read the latest snapshot) ──────────────────────
+
+    def _observe_lag(self, options: CallbackOptions) -> Iterable[Observation]:
+        yield Observation(self._snapshot.outbox_lag_seconds)
+
+    def _observe_pending(self, options: CallbackOptions) -> Iterable[Observation]:
+        for group, count in self._snapshot.pending_by_group.items():
+            yield Observation(count, {"consumer_group": group})
+
+    def _observe_failed(self, options: CallbackOptions) -> Iterable[Observation]:
+        for group, count in self._snapshot.failed_by_group.items():
+            yield Observation(count, {"consumer_group": group})
+
+    def _observe_pool_checked_out(self, options: CallbackOptions) -> Iterable[Observation]:
+        pool = self._snapshot.pool
+        if pool is not None:
+            yield Observation(pool.checked_out)
+
+    def _observe_pool_size(self, options: CallbackOptions) -> Iterable[Observation]:
+        pool = self._snapshot.pool
+        if pool is not None:
+            yield Observation(pool.size)
+
+    def _observe_pool_overflow(self, options: CallbackOptions) -> Iterable[Observation]:
+        pool = self._snapshot.pool
+        if pool is not None:
+            yield Observation(pool.overflow)
+
+    def _observe_workers_busy(self, options: CallbackOptions) -> Iterable[Observation]:
+        yield Observation(self._snapshot.workers_busy)
+
+    def _observe_workers_total(self, options: CallbackOptions) -> Iterable[Observation]:
+        yield Observation(self._snapshot.workers_total)
+
+    # ── Async refresh (owned by the WorkerPool loop) ──────────────────────────
+
+    async def refresh(self, container: AsyncContainer, workers: Sequence["Worker"]) -> None:
+        """Sample every source and atomically swap in a fresh snapshot.
+
+        Opens a UOW scope as the System identity (like the pool's other
+        housekeeping loops), reads outbox delivery health, the DB pool, and the
+        live worker states, then assembles a new :class:`SamplerSnapshot`.
+        """
+        try:
+            async with container(scope=Scope.UOW, context={Identity: System()}) as scope:
+                repo = await scope.get(EventRepository)
+                stats = await repo.delivery_stats()
+
+            oldest = stats.oldest_pending_created_at
+            if oldest is not None:
+                lag = max(0.0, (datetime.now(UTC) - oldest).total_seconds())
+            else:
+                lag = 0.0
+
+            pending_by_group = {
+                group: count
+                for (group, status), count in stats.counts.items()
+                if status is DeliveryStatus.PENDING
+            }
+            failed_by_group = {
+                group: count
+                for (group, status), count in stats.counts.items()
+                if status is DeliveryStatus.FAILED
+            }
+
+            pool = self._engine.sync_engine.pool
+            # SQLite StaticPool has no meaningful occupancy stats — skip it.
+            pool_stats = (
+                PoolStats(
+                    checked_out=pool.checkedout(),
+                    size=pool.size(),
+                    overflow=pool.overflow(),
+                )
+                if isinstance(pool, QueuePool)
+                else None
+            )
+
+            workers_busy = sum(1 for w in workers if w.state.status is WorkerStatus.PROCESSING)
+
+            self._snapshot = SamplerSnapshot(
+                outbox_lag_seconds=lag,
+                pending_by_group=pending_by_group,
+                failed_by_group=failed_by_group,
+                pool=pool_stats,
+                workers_busy=workers_busy,
+                workers_total=len(workers),
+            )
+        except Exception as exc:
+            # A stale gauge beats a crashed sampler: warn and keep the previous
+            # snapshot so the loop survives and metrics merely go stale.
+            logger.warn("Telemetry sampler refresh failed: {error}", error=str(exc))

--- a/server/osa/infrastructure/telemetry/setup.py
+++ b/server/osa/infrastructure/telemetry/setup.py
@@ -23,7 +23,13 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.sdk._logs import LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics import Histogram
 from opentelemetry.sdk.metrics.export import MetricReader, PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.view import (
+    ExplicitBucketHistogramAggregation,
+    ExponentialBucketHistogramAggregation,
+    View,
+)
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanProcessor
 from prometheus_client import REGISTRY as _PROMETHEUS_DEFAULT_REGISTRY
 from prometheus_client import CollectorRegistry
@@ -69,6 +75,33 @@ class TelemetryBootstrap:
     def prometheus_registry(self) -> CollectorRegistry | None:
         """The owned Prometheus registry ``/metrics`` renders, or None when disabled."""
         return self._prometheus_registry
+
+    @staticmethod
+    def _metric_views(*, prometheus_enabled: bool) -> list[View]:
+        """Logfire's default views, made Prometheus-compatible when needed.
+
+        With the pull endpoint off, logfire's defaults stand (exponential
+        histograms — better resolution, smaller payloads). With it on, the
+        exponential-aggregation view is replaced by explicit buckets, because
+        prometheus-exporter 0.60b1 raises ``AttributeError`` on
+        ``ExponentialHistogramDataPoint`` during collection. The other default
+        views (e.g. ``http.server.active_requests`` attribute filtering) are
+        kept either way.
+        """
+        defaults = list(logfire.MetricsOptions.DEFAULT_VIEWS)
+        if not prometheus_enabled:
+            return defaults
+        views = [
+            v
+            for v in defaults
+            if not isinstance(
+                getattr(v, "_aggregation", None), ExponentialBucketHistogramAggregation
+            )
+        ]
+        views.append(
+            View(instrument_type=Histogram, aggregation=ExplicitBucketHistogramAggregation())
+        )
+        return views
 
     def configure(self, config: Config) -> None:
         """Configure the process-global telemetry pipeline exactly once.
@@ -130,6 +163,13 @@ class TelemetryBootstrap:
             else None
         )
 
+        # Logfire's default views aggregate all histograms into exponential
+        # buckets, which the Prometheus exporter cannot render (its collector
+        # crashes on ExponentialHistogramDataPoint at scrape time). Views are
+        # provider-wide, so when the pull endpoint is on we fall back to
+        # explicit buckets for every histogram — OTLP consumers handle both.
+        views = self._metric_views(prometheus_enabled=obs.prometheus_enabled)
+
         logfire.configure(
             send_to_logfire="if-token-present",
             service_name=config.name,
@@ -137,7 +177,7 @@ class TelemetryBootstrap:
             console=False,  # we render spans via OSAConsoleExporter
             inspect_arguments=False,
             additional_span_processors=span_processors,
-            metrics=logfire.MetricsOptions(additional_readers=list(metric_readers)),
+            metrics=logfire.MetricsOptions(additional_readers=list(metric_readers), views=views),
             sampling=logfire.SamplingOptions(head=obs.trace_sample_rate),
             advanced=advanced,
         )

--- a/server/osa/infrastructure/telemetry/setup.py
+++ b/server/osa/infrastructure/telemetry/setup.py
@@ -1,0 +1,169 @@
+"""Process-wide telemetry bootstrap (metrics + logs + traces via Logfire).
+
+Extracts the inline ``logfire.configure(...)`` block that used to live in
+``app.py`` and extends it with OSA's observability config: an owned Prometheus
+pull registry, optional OTLP/HTTP push of all three signals, and head sampling.
+
+Why a module singleton (:data:`bootstrap`): logfire's provider wiring and
+Prometheus collector registration are *process*-global. Test suites build many
+apps per process via ``create_app()``; re-running ``logfire.configure`` or
+re-registering a Prometheus collector would corrupt global state or raise
+``Duplicated timeseries``. :class:`TelemetryBootstrap` guards that with a
+configure-once flag and an owned :class:`CollectorRegistry` (never the
+prometheus_client default ``REGISTRY``).
+"""
+
+import logging
+import sys
+
+import logfire
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from opentelemetry.sdk._logs import LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics.export import MetricReader, PeriodicExportingMetricReader
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanProcessor
+from prometheus_client import REGISTRY as _PROMETHEUS_DEFAULT_REGISTRY
+from prometheus_client import CollectorRegistry
+
+from osa.config import Config
+from osa.infrastructure.logging import OSAConsoleExporter, get_logger
+
+logger = get_logger(__name__)
+
+
+class _OwnedRegistryPrometheusReader(PrometheusMetricReader):
+    """A :class:`PrometheusMetricReader` bound to an *owned* CollectorRegistry.
+
+    ``PrometheusMetricReader`` (exporter-prometheus 0.60b1) has no registry
+    kwarg: ``__init__`` unconditionally registers its collector into the
+    process-global default ``REGISTRY``, and ``shutdown`` unregisters it from
+    the same. We want an owned registry instead (so ``/metrics`` renders only
+    OSA's collector, never the global default's process/platform collectors),
+    so the cleanest supported path is to let the base register into the default,
+    then relocate the collector into the owned registry — and mirror that in an
+    overridden ``shutdown`` so teardown unregisters from the right registry (no
+    KeyError against the global default at process exit).
+    """
+
+    def __init__(self, registry: CollectorRegistry) -> None:
+        self._owned_registry = registry
+        super().__init__()
+        _PROMETHEUS_DEFAULT_REGISTRY.unregister(self._collector)
+        registry.register(self._collector)
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs: object) -> None:
+        self._owned_registry.unregister(self._collector)
+
+
+class TelemetryBootstrap:
+    """Process-wide telemetry configuration. Idempotent: configure() runs once per process."""
+
+    def __init__(self) -> None:
+        self._configured = False
+        self._prometheus_registry: CollectorRegistry | None = None
+
+    @property
+    def prometheus_registry(self) -> CollectorRegistry | None:
+        """The owned Prometheus registry ``/metrics`` renders, or None when disabled."""
+        return self._prometheus_registry
+
+    def configure(self, config: Config) -> None:
+        """Configure the process-global telemetry pipeline exactly once.
+
+        Reproduces the original ``app.py`` logfire block (console span exporter,
+        stdlib-root → Logfire handler bridge, uvicorn.access suppression) and
+        extends it with service version, head sampling, an owned Prometheus
+        reader, and — when an OTLP endpoint is set — OTLP/HTTP push of traces,
+        metrics, and logs.
+        """
+        if self._configured:
+            logger.debug("Telemetry already configured for this process; skipping.")
+            return
+
+        obs = config.observability
+
+        # Base span processors: the console exporter is always present (parity
+        # with the original app.py block).
+        span_processors: list[SpanProcessor] = [
+            SimpleSpanProcessor(
+                OSAConsoleExporter(
+                    output=sys.stderr,
+                    include_timestamp=True,
+                    min_log_level=config.logging.level,
+                )
+            ),
+        ]
+        metric_readers: list[MetricReader] = []
+        log_processors: list[BatchLogRecordProcessor] = []
+
+        if obs.prometheus_enabled:
+            self._prometheus_registry = CollectorRegistry()
+            metric_readers.append(_OwnedRegistryPrometheusReader(self._prometheus_registry))
+
+        if obs.otlp_endpoint is not None:
+            base = obs.otlp_endpoint.rstrip("/")
+            headers = (
+                {"Authorization": f"Bearer {obs.otlp_token.get_secret_value()}"}
+                if obs.otlp_token is not None
+                else None
+            )
+            span_processors.append(
+                BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{base}/v1/traces", headers=headers))
+            )
+            metric_readers.append(
+                PeriodicExportingMetricReader(
+                    OTLPMetricExporter(endpoint=f"{base}/v1/metrics", headers=headers)
+                )
+            )
+            log_processors.append(
+                BatchLogRecordProcessor(
+                    OTLPLogExporter(endpoint=f"{base}/v1/logs", headers=headers)
+                )
+            )
+
+        advanced = (
+            logfire.AdvancedOptions(log_record_processors=list(log_processors))
+            if log_processors
+            else None
+        )
+
+        logfire.configure(
+            send_to_logfire="if-token-present",
+            service_name=config.name,
+            service_version=config.version,
+            console=False,  # we render spans via OSAConsoleExporter
+            inspect_arguments=False,
+            additional_span_processors=span_processors,
+            metrics=logfire.MetricsOptions(additional_readers=list(metric_readers)),
+            sampling=logfire.SamplingOptions(head=obs.trace_sample_rate),
+            advanced=advanced,
+        )
+
+        # Route stdlib logging through logfire so legacy logger.info() calls land
+        # in the same stream. When OTLP is on, also feed the stdlib root into the
+        # OTLP logs signal so those records reach the collector.
+        root = logging.getLogger()
+        root.setLevel(config.logging.level.upper())
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+        root.addHandler(logfire.LogfireLoggingHandler())
+        if log_processors:
+            root.addHandler(LoggingHandler())
+
+        # logfire's FastAPI instrumentation already emits HTTP access telemetry.
+        logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
+        logger.info(
+            "Telemetry configured",
+            prometheus_enabled=obs.prometheus_enabled,
+            otlp_endpoint=obs.otlp_endpoint,  # never the token
+            trace_sample_rate=obs.trace_sample_rate,
+        )
+        self._configured = True
+
+
+bootstrap = TelemetryBootstrap()
+"""Module singleton — telemetry is process-global by nature (like logfire itself)."""

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "python-multipart>=0.0.22",
     "slowapi>=0.1.9",
+    "opentelemetry-exporter-prometheus==0.60b1",
 ]
 
 [project.entry-points."osa.sources"]

--- a/server/tests/unit/application/test_app_factory.py
+++ b/server/tests/unit/application/test_app_factory.py
@@ -247,8 +247,17 @@ class TestCreateApp:
         assert CustomHandler in handler_types
 
     def test_default_create_app_serves_health(self):
-        """Default create_app produces a working app."""
+        """Default create_app produces a working app.
+
+        Liveness returns the real running version (from Config), not the old
+        hardcoded "0.1.0".
+        """
+        from osa.config import Config
+
         app = create_app()
         client = TestClient(app, raise_server_exceptions=False)
         response = client.get("/api/v1/health")
         assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["version"] == Config().version

--- a/server/tests/unit/application/test_health_ready.py
+++ b/server/tests/unit/application/test_health_ready.py
@@ -1,0 +1,152 @@
+"""Contract tests for the liveness/readiness endpoints (#158, P7).
+
+Drives ``/api/v1/health`` and ``/api/v1/ready`` through a TestClient built by
+``create_app``. The readiness component checks (db, workers, runner) are steered
+deterministically with ``@provide(..., override=True)`` providers so both the
+ready and degraded paths can be exercised without a real Postgres or a started
+worker pool.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from dishka import provide
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from osa.application.api.rest.app import create_app
+from osa.config import Config
+from osa.infrastructure.event.worker import WorkerPool
+from osa.util.di.base import Provider
+from osa.util.di.scope import Scope
+
+os.environ.setdefault(
+    "OSA_AUTH__JWT__SECRET",
+    "test-secret-that-is-at-least-32-characters-long",
+)
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+
+
+# ---------------------------------------------------------------------------
+# Fakes + override providers
+# ---------------------------------------------------------------------------
+
+
+class _OkSession:
+    """Session whose SELECT 1 succeeds."""
+
+    async def execute(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        return None
+
+
+class _FailSession:
+    """Session whose SELECT 1 raises — drives the degraded db path."""
+
+    async def execute(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        raise RuntimeError("connection refused")
+
+
+def _alive_pool() -> WorkerPool:
+    pool = WorkerPool()
+    pool._workers.append(SimpleNamespace(is_alive=True, name="FakeWorker"))
+    return pool
+
+
+class OkDbProvider(Provider):
+    @provide(scope=Scope.UOW, override=True)
+    def get_session(self) -> AsyncSession:
+        return _OkSession()  # type: ignore[return-value]
+
+
+class FailDbProvider(Provider):
+    @provide(scope=Scope.UOW, override=True)
+    def get_session(self) -> AsyncSession:
+        return _FailSession()  # type: ignore[return-value]
+
+
+class AlivePoolProvider(Provider):
+    @provide(scope=Scope.APP, override=True)
+    def get_worker_pool(self) -> WorkerPool:
+        return _alive_pool()
+
+
+# Skip handler auth validation (other modules define handlers without __auth__).
+_PATCH = patch("osa.application.api.rest.app.validate_all_handlers")
+
+
+def setup_module(module):  # noqa: ANN001, ANN201
+    _PATCH.start()
+
+
+def teardown_module(module):  # noqa: ANN001, ANN201
+    _PATCH.stop()
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    def test_health_reports_ok_and_config_version(self):
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        # Not the old hardcoded "0.1.0" — the real running version.
+        assert body["version"] == Config().version
+
+
+# ---------------------------------------------------------------------------
+# /ready
+# ---------------------------------------------------------------------------
+
+
+class TestReady:
+    def test_all_ok_is_ready_200(self):
+        app = create_app(providers=[OkDbProvider(), AlivePoolProvider()])
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/ready")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ready"
+        assert set(body["components"]) == {"db", "workers", "runner"}
+        assert body["components"]["db"]["status"] == "ok"
+        assert body["components"]["workers"]["status"] == "ok"
+        # OCI is the default backend — runner is unchecked, not an error.
+        assert body["components"]["runner"]["status"] == "unchecked"
+        assert body["version"] == Config().version
+
+    def test_runner_unchecked_does_not_degrade(self):
+        app = create_app(providers=[OkDbProvider(), AlivePoolProvider()])
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/ready")
+        # unchecked runner + ok required components => still 200/ready.
+        assert resp.status_code == 200
+        assert resp.json()["components"]["runner"]["status"] == "unchecked"
+
+    def test_db_failure_degrades_to_503(self):
+        app = create_app(providers=[FailDbProvider(), AlivePoolProvider()])
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/ready")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["components"]["db"]["status"] == "error"
+        assert body["components"]["db"]["detail"]  # carries the exception message
+        # Other components are still reported alongside the failure.
+        assert body["components"]["workers"]["status"] == "ok"
+        assert body["components"]["runner"]["status"] == "unchecked"
+
+    def test_unstarted_worker_pool_degrades(self):
+        # Default (real) worker pool is un-started under TestClient (no lifespan).
+        app = create_app(providers=[OkDbProvider()])
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/ready")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["components"]["workers"]["status"] == "error"
+        assert body["components"]["db"]["status"] == "ok"

--- a/server/tests/unit/application/test_metrics_endpoint.py
+++ b/server/tests/unit/application/test_metrics_endpoint.py
@@ -1,0 +1,78 @@
+"""Contract tests for the unversioned ``GET /metrics`` endpoint (#158, P7).
+
+The Prometheus registry is process-global (configure-once). These tests assert
+the exposition format and the disabled-path gating without depending on which
+earlier test configured the bootstrap.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from osa.application.api.rest.app import create_app
+from osa.infrastructure.telemetry.setup import bootstrap
+
+os.environ.setdefault(
+    "OSA_AUTH__JWT__SECRET",
+    "test-secret-that-is-at-least-32-characters-long",
+)
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+
+_PATCH = patch("osa.application.api.rest.app.validate_all_handlers")
+
+
+def setup_module(module):  # noqa: ANN001, ANN201
+    _PATCH.start()
+
+
+def teardown_module(module):  # noqa: ANN001, ANN201
+    _PATCH.stop()
+
+
+class TestMetricsEnabled:
+    def test_metrics_serves_prometheus_text(self):
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        # Prometheus exposition is text/plain (with version + charset params).
+        assert resp.headers["content-type"].startswith("text/plain")
+        # Only assert the OSA metric family if this process actually configured
+        # a prometheus registry (default-enabled, but configure-once per process).
+        if bootstrap.prometheus_registry is not None:
+            assert "osa_" in resp.text or resp.text == "" or "# HELP" in resp.text
+
+    def test_repeated_create_app_metrics_stays_200(self):
+        # The configure-once guard + owned registry must survive a second app.
+        app1 = create_app()
+        app2 = create_app()
+        for app in (app1, app2):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/metrics")
+            assert resp.status_code == 200
+
+
+class TestMetricsDisabled:
+    def test_disabled_registry_returns_404(self):
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        # Simulate prometheus disabled by swapping the module-level bootstrap
+        # for a stub whose owned registry is None.
+        stub = SimpleNamespace(prometheus_registry=None)
+        with patch("osa.application.api.v1.routes.metrics.bootstrap", stub):
+            resp = client.get("/metrics")
+        assert resp.status_code == 404
+        assert "prometheus" in resp.json()["detail"].lower()
+
+
+class TestTracingExclusions:
+    def test_health_ready_metrics_excluded_from_tracing(self):
+        with patch("osa.application.api.rest.app.logfire.instrument_fastapi") as mock:
+            create_app()
+        _, kwargs = mock.call_args
+        excluded = kwargs["excluded_urls"]
+        assert "/api/v1/health" in excluded
+        assert "/api/v1/ready" in excluded
+        assert "/metrics" in excluded

--- a/server/tests/unit/config/test_config.py
+++ b/server/tests/unit/config/test_config.py
@@ -179,3 +179,48 @@ class TestDataConfig:
     def test_max_page_limit_yaml_override(self):
         cfg = config_from_yaml({"data": {"max_page_limit": 250}})
         assert cfg.data.max_page_limit == 250
+
+
+class TestObservabilityConfig:
+    """Telemetry export configuration group (metrics/logs/traces), OSA_OBSERVABILITY__*."""
+
+    def test_defaults(self):
+        """Fresh Config has push export disabled, Prometheus on, full sampling, no token."""
+        cfg = config_from_yaml({})
+        assert cfg.observability.otlp_endpoint is None
+        assert cfg.observability.otlp_token is None
+        assert cfg.observability.prometheus_enabled is True
+        assert cfg.observability.trace_sample_rate == 1.0
+
+    def test_env_override(self):
+        """OSA_OBSERVABILITY__* env vars populate the nested group."""
+        cfg = config_from_yaml(
+            {},
+            env_overrides={
+                "OSA_OBSERVABILITY__OTLP_ENDPOINT": "https://otlp.example.com",
+                "OSA_OBSERVABILITY__PROMETHEUS_ENABLED": "false",
+                "OSA_OBSERVABILITY__TRACE_SAMPLE_RATE": "0.25",
+                "OSA_OBSERVABILITY__OTLP_TOKEN": "sekrit",
+            },
+        )
+        assert cfg.observability.otlp_endpoint == "https://otlp.example.com"
+        assert cfg.observability.prometheus_enabled is False
+        assert cfg.observability.trace_sample_rate == 0.25
+        assert cfg.observability.otlp_token is not None
+        assert cfg.observability.otlp_token.get_secret_value() == "sekrit"
+
+    def test_trace_sample_rate_above_one_raises(self):
+        """trace_sample_rate > 1.0 fails validation."""
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            config_from_yaml(
+                {},
+                env_overrides={"OSA_OBSERVABILITY__TRACE_SAMPLE_RATE": "1.5"},
+            )
+
+    def test_trace_sample_rate_below_zero_raises(self):
+        """trace_sample_rate < 0.0 fails validation."""
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            config_from_yaml(
+                {},
+                env_overrides={"OSA_OBSERVABILITY__TRACE_SAMPLE_RATE": "-0.1"},
+            )

--- a/server/tests/unit/domain/ingest/test_get_ingestion.py
+++ b/server/tests/unit/domain/ingest/test_get_ingestion.py
@@ -1,7 +1,7 @@
 """Tests for GetIngestion — a failed run carries a queryable explanation (#152)."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -92,6 +92,7 @@ class TestGetIngestionService:
             convention_service=AsyncMock(),
             outbox=AsyncMock(),
             node_domain=Domain("localhost"),
+            instrumentation=MagicMock(),
         )
 
         with pytest.raises(NotFoundError):

--- a/server/tests/unit/domain/ingest/test_ingest_service.py
+++ b/server/tests/unit/domain/ingest/test_ingest_service.py
@@ -1,5 +1,6 @@
 """T022: Unit tests for IngestService.start_ingest."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,24 @@ from osa.domain.ingest.service.ingest import IngestService
 from osa.domain.shared.error import ConflictError, NotFoundError
 from osa.domain.shared.model.source import IngesterDefinition
 from osa.domain.shared.model.srn import Domain
+
+
+class RecordingIngestInstrumentation:
+    """Records IngestInstrumentation calls for assertion (no MagicMock indirection)."""
+
+    def __init__(self) -> None:
+        self.batches_completed: list[int] = []
+        self.batches_failed: list = []
+        self.runs_finished: list[tuple] = []
+
+    def batch_completed(self, *, published_count) -> None:  # noqa: ANN001
+        self.batches_completed.append(published_count)
+
+    def batch_failed(self, *, kind) -> None:  # noqa: ANN001
+        self.batches_failed.append(kind)
+
+    def run_finished(self, *, status, kind) -> None:  # noqa: ANN001
+        self.runs_finished.append((status, kind))
 
 
 def _make_convention(*, has_ingester: bool = True):
@@ -48,6 +67,7 @@ def _make_service(
         convention_service=convention_service,
         outbox=outbox,
         node_domain=Domain("localhost"),
+        instrumentation=RecordingIngestInstrumentation(),
     )
 
 
@@ -290,3 +310,120 @@ class TestTerminalRunAccountingIsFrozen:
 
         service.ingest_repo.increment_failed.assert_not_awaited()
         service.ingest_repo.record_failure.assert_not_awaited()
+
+
+class TestIngestMetricsEmission:
+    """IngestService emits batch/run telemetry at the Applied arms and terminal
+    transitions — exactly once per terminal run."""
+
+    @pytest.mark.asyncio
+    async def test_complete_batch_emits_batch_completed(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        run = MagicMock(id="run-1", published_count=5)
+        run.check_completion.return_value = False
+        service.ingest_repo.increment_completed.return_value = Applied(run=run)
+
+        await service.complete_batch(IngestRunId("run-1"), published_count=5)
+
+        assert service.instrumentation.batches_completed == [5]
+        assert service.instrumentation.runs_finished == []
+
+    @pytest.mark.asyncio
+    async def test_complete_batch_noop_emits_nothing(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+
+        service = _make_service()
+        service.ingest_repo.increment_completed.return_value = RunClosed()
+
+        await service.complete_batch(IngestRunId("run-1"), published_count=5)
+
+        assert service.instrumentation.batches_completed == []
+
+    @pytest.mark.asyncio
+    async def test_completion_emits_run_finished_once(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId
+
+        service = _make_service()
+        run = IngestRun(
+            id=IngestRunId("run-1"),
+            convention_id="test-conv",
+            status=IngestStatus.RUNNING,
+            ingestion_finished=True,
+            batches_ingested=1,
+            batches_completed=0,
+            published_count=3,
+            started_at=datetime.now(UTC),
+        )
+        # increment_completed returns the run that now satisfies completion.
+        run.batches_completed = 1
+        service.ingest_repo.increment_completed.return_value = Applied(run=run)
+
+        await service.complete_batch(IngestRunId("run-1"), published_count=3)
+
+        assert service.instrumentation.runs_finished == [(IngestStatus.COMPLETED, None)]
+
+    @pytest.mark.asyncio
+    async def test_fail_batch_emits_batch_failed(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        run = MagicMock(id="run-1", published_count=0)
+        run.check_completion.return_value = False
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
+
+        await service.fail_batch(IngestRunId("run-1"), reason="boom", kind=FailureKind.HOOK_EXIT)
+
+        assert service.instrumentation.batches_failed == [FailureKind.HOOK_EXIT]
+
+    @pytest.mark.asyncio
+    async def test_fail_ingestion_emits_batch_failed(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        run = MagicMock(id="run-1", published_count=0)
+        run.check_completion.return_value = False
+        service.ingest_repo.increment_batches_ingested.return_value = Applied(run=run)
+        service.ingest_repo.increment_failed.return_value = Applied(run=run)
+
+        await service.fail_ingestion(
+            IngestRunId("run-1"), reason="upstream 500", kind=FailureKind.UPSTREAM
+        )
+
+        assert service.instrumentation.batches_failed == [FailureKind.UPSTREAM]
+
+    @pytest.mark.asyncio
+    async def test_abort_emits_run_finished_failed(self) -> None:
+        from datetime import datetime as _dt
+
+        from osa.domain.ingest.model.ingest_run import IngestRun, IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        service.ingest_repo.abort.return_value = Applied(
+            run=IngestRun(
+                id=IngestRunId("run-1"),
+                convention_id="test-conv",
+                status=IngestStatus.FAILED,
+                started_at=_dt.now(UTC),
+            )
+        )
+
+        await service.abort_run(IngestRunId("run-1"), reason="rbac denied", kind=FailureKind.RBAC)
+
+        assert service.instrumentation.runs_finished == [(IngestStatus.FAILED, FailureKind.RBAC)]
+
+    @pytest.mark.asyncio
+    async def test_abort_noop_emits_no_run_finished(self) -> None:
+        from osa.domain.ingest.model.ingest_run import IngestRunId
+        from osa.domain.shared.failure import FailureKind
+
+        service = _make_service()
+        service.ingest_repo.abort.return_value = RunClosed()
+
+        await service.abort_run(IngestRunId("run-1"), reason="x", kind=FailureKind.RBAC)
+
+        assert service.instrumentation.runs_finished == []

--- a/server/tests/unit/domain/ingest/test_run_hooks.py
+++ b/server/tests/unit/domain/ingest/test_run_hooks.py
@@ -27,6 +27,20 @@ from osa.domain.validation.model.hook_run import HookRunStatus
 _T0 = datetime(2026, 1, 1, tzinfo=UTC)
 
 
+class RecordingHookInstrumentation:
+    """Records HookInstrumentation calls for assertion (no MagicMock indirection)."""
+
+    def __init__(self) -> None:
+        self.runs_finished: list[tuple] = []
+        self.failures_decided: list[tuple] = []
+
+    def run_finished(self, *, hook, status, duration_s, oom_retries) -> None:  # noqa: ANN001
+        self.runs_finished.append((hook, status, duration_s, oom_retries))
+
+    def run_failure_decided(self, *, hook, kind, decision) -> None:  # noqa: ANN001
+        self.failures_decided.append((hook, kind, decision))
+
+
 def _make_release(name: str = "pockets") -> HookRelease:
     return HookRelease(
         id=HookReleaseId(uuid4()),
@@ -130,6 +144,7 @@ def _make_handler(*, hook_names: tuple[str, ...] = ("pockets",), executions=None
         outbox=AsyncMock(),
         ingest_storage=ingest_storage,
         failure_policy=FailurePolicy(),
+        instrumentation=RecordingHookInstrumentation(),
     )
 
 
@@ -332,3 +347,71 @@ class TestBatchExhaustionRecordsReason:
         assert "exhausted" in call.kwargs["reason"]
         assert "3" in call.kwargs["reason"]
         assert call.kwargs["kind"] is None
+
+
+class TestHookMetricsEmission:
+    """RunHooks emits one run_finished per recorded execution and one
+    run_failure_decided per (execution, decision)."""
+
+    @pytest.mark.asyncio
+    async def test_run_finished_emitted_per_execution(self) -> None:
+        execs = [
+            _passed_exec("hook_a", offset=0),
+            _failed_exec("hook_b", FailureKind.HOOK_EXIT, offset=10),
+        ]
+        handler = _make_handler(hook_names=("hook_a", "hook_b"), executions=execs)
+
+        await handler.handle(_make_event())
+
+        inst = handler.instrumentation
+        by_hook = {h.root: (status, dur, oom) for h, status, dur, oom in inst.runs_finished}
+        assert by_hook["hook_a"] == (HookRunStatus.PASSED, 5.0, 0)
+        assert by_hook["hook_b"] == (HookRunStatus.ERROR, 2.0, 0)
+
+    @pytest.mark.asyncio
+    async def test_failure_decided_emitted_for_failed_hook(self) -> None:
+        from osa.domain.shared.failure import DecisionKind
+
+        # HOOK_EXIT → GiveUp; the batch still completes.
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.HOOK_EXIT)])
+
+        await handler.handle(_make_event())
+
+        inst = handler.instrumentation
+        assert len(inst.failures_decided) == 1
+        hook, kind, decision = inst.failures_decided[0]
+        assert hook.root == "pockets"
+        assert kind is FailureKind.HOOK_EXIT
+        assert decision is DecisionKind.GIVE_UP
+
+    @pytest.mark.asyncio
+    async def test_passed_only_batch_decides_no_failures(self) -> None:
+        handler = _make_handler(executions=[_passed_exec("pockets")])
+
+        await handler.handle(_make_event())
+
+        assert handler.instrumentation.failures_decided == []
+        assert len(handler.instrumentation.runs_finished) == 1
+
+    @pytest.mark.asyncio
+    async def test_abort_records_run_finished_and_decision(self) -> None:
+        from osa.domain.shared.failure import DecisionKind
+
+        # IMAGE_PULL → AbortRun; provenance is still recorded (run_finished fires).
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.IMAGE_PULL)])
+
+        await handler.handle(_make_event())
+
+        inst = handler.instrumentation
+        assert len(inst.runs_finished) == 1
+        assert inst.runs_finished[0][1] == HookRunStatus.ERROR
+        assert inst.failures_decided[0][2] is DecisionKind.ABORT_RUN
+
+    @pytest.mark.asyncio
+    async def test_oom_run_finished_carries_retry_count(self) -> None:
+        handler = _make_handler(executions=[_failed_exec("pockets", FailureKind.OOM)])
+
+        await handler.handle(_make_event())
+
+        # _failed_exec sets oom_retries=3 for OOM.
+        assert handler.instrumentation.runs_finished[0][3] == 3

--- a/server/tests/unit/infrastructure/event/test_worker.py
+++ b/server/tests/unit/infrastructure/event/test_worker.py
@@ -15,12 +15,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from osa.domain.shared.event import (
     ClaimResult,
     Delivery,
+    DeliveryStatus,
     Event,
     EventHandler,
     EventId,
     WorkerStatus,
 )
 from osa.domain.shared.outbox import Outbox
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation
+
+
+class RecordingOutboxInstrumentation:
+    """Records delivery_completed calls for assertion (no MagicMock indirection)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, DeliveryStatus, int, float]] = []
+
+    def delivery_completed(self, *, consumer_group, status, retry_count, duration_s) -> None:  # noqa: ANN001
+        self.calls.append((consumer_group, status, retry_count, duration_s))
 
 
 class DummyEvent(Event):
@@ -53,21 +65,27 @@ def make_mock_container(
     outbox: AsyncMock,
     session: AsyncMock | None = None,
     handler: EventHandler | None = None,
+    instrumentation: RecordingOutboxInstrumentation | None = None,
 ):
     """Create a mock DI container that provides scoped dependencies.
 
-    Creates a container mock that returns Outbox, AsyncSession, and handler
-    when called as an async context manager with scope parameter.
+    Creates a container mock that returns Outbox, AsyncSession, handler, and
+    OutboxInstrumentation when called as an async context manager with scope.
     """
     if session is None:
         session = AsyncMock(spec=AsyncSession)
         session.commit = AsyncMock()
         session.rollback = AsyncMock()
 
+    if instrumentation is None:
+        instrumentation = RecordingOutboxInstrumentation()
+
     async def get_dependency(cls):
         """Return the appropriate dependency based on the requested class."""
         if cls == Outbox:
             return outbox
+        if cls == OutboxInstrumentation:
+            return instrumentation
         if cls == AsyncSession:
             return session
         if handler is not None and (cls is type(handler) or issubclass(cls, EventHandler)):
@@ -367,3 +385,205 @@ class TestWorkerStartStop:
         assert call_args[1]["deliver_after"] is not None
         assert worker.state.failed_count == 1
         assert worker.state.error is not None
+
+
+# Two distinct, valid, sampled W3C traceparents (flags=01).
+_TP1 = "00-11111111111111111111111111111111-2222222222222222-01"
+_TP2 = "00-33333333333333333333333333333333-4444444444444444-01"
+
+
+class TestLinksFromDeliveries:
+    """Worker._links_from_deliveries turns claimed traceparents into span links."""
+
+    def test_valid_traceparents_become_links(self):
+        from osa.infrastructure.event.worker import Worker
+
+        worker = Worker(DummyHandler)
+        d1 = Delivery(id="del-1", event=None, trace_context=_TP1)  # type: ignore[arg-type]
+        d2 = Delivery(id="del-2", event=None, trace_context=_TP2)  # type: ignore[arg-type]
+
+        links = worker._links_from_deliveries([d1, d2])
+
+        assert len(links) == 2
+        (sc1, attrs1), (sc2, attrs2) = links
+        assert sc1.trace_id == int("1" * 32, 16)
+        assert sc2.trace_id == int("3" * 32, 16)
+        assert attrs1 == {"delivery.id": "del-1"}
+        assert attrs2 == {"delivery.id": "del-2"}
+
+    def test_malformed_traceparent_is_skipped_with_warning(self, monkeypatch):
+        import osa.infrastructure.event.worker as worker_module
+        from osa.infrastructure.event.worker import Worker
+
+        fake_logger = MagicMock()
+        monkeypatch.setattr(worker_module, "logger", fake_logger)
+
+        worker = Worker(DummyHandler)
+        good = Delivery(id="ok", event=None, trace_context=_TP1)  # type: ignore[arg-type]
+        bad = Delivery(id="bad", event=None, trace_context="garbage")  # type: ignore[arg-type]
+
+        links = worker._links_from_deliveries([good, bad])
+
+        # The good one still links; the bad one is dropped, not fatal.
+        assert len(links) == 1
+        assert links[0][1] == {"delivery.id": "ok"}
+        assert fake_logger.warn.call_count == 1
+
+    def test_none_trace_context_skipped_silently(self, monkeypatch):
+        import osa.infrastructure.event.worker as worker_module
+        from osa.infrastructure.event.worker import Worker
+
+        fake_logger = MagicMock()
+        monkeypatch.setattr(worker_module, "logger", fake_logger)
+
+        worker = Worker(DummyHandler)
+        d = Delivery(id="del-1", event=None, trace_context=None)  # type: ignore[arg-type]
+
+        links = worker._links_from_deliveries([d])
+
+        assert links == []
+        fake_logger.warn.assert_not_called()
+
+
+class TestDispatchSpan:
+    """Dispatch is wrapped in a worker.dispatch span whose _links come from the batch."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_span_receives_batch_links(self, monkeypatch):
+        import osa.infrastructure.event.worker as worker_module
+        from osa.infrastructure.event.worker import Worker
+
+        captured: dict = {}
+
+        class _FakeSpan:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_span(msg, **kwargs):
+            captured["msg"] = msg
+            captured["kwargs"] = kwargs
+            return _FakeSpan()
+
+        monkeypatch.setattr(worker_module.logfire, "span", fake_span)
+
+        event = DummyEvent(id=EventId(uuid4()), data="event1")
+        claim_result = ClaimResult(
+            deliveries=[Delivery(id="del-1", event=event, trace_context=_TP1)],
+            claimed_at=datetime.now(UTC),
+        )
+        outbox = AsyncMock(spec=Outbox)
+        outbox.claim.return_value = claim_result
+        outbox.mark_delivered = AsyncMock()
+
+        handler = DummyHandler(processed_events=[])
+        container = make_mock_container(outbox, handler=handler)
+
+        worker = Worker(DummyHandler)
+        worker.set_container(container)
+
+        await worker._poll_once()
+
+        assert captured["msg"] == "worker.dispatch {consumer_group}"
+        assert captured["kwargs"]["consumer_group"] == "DummyHandler"
+        assert captured["kwargs"]["batch_size"] == 1
+        links = captured["kwargs"]["_links"]
+        assert len(links) == 1
+        assert links[0][1] == {"delivery.id": "del-1"}
+
+
+class TestDeliveryMetrics:
+    """Worker emits delivery_completed per delivery in each terminal branch."""
+
+    @pytest.mark.asyncio
+    async def test_success_emits_delivered(self):
+        from osa.infrastructure.event.worker import Worker
+
+        event = DummyEvent(id=EventId(uuid4()), data="e")
+        claim_result = ClaimResult(
+            deliveries=[Delivery(id="del-1", event=event, retry_count=2)],
+            claimed_at=datetime.now(UTC),
+        )
+        outbox = AsyncMock(spec=Outbox)
+        outbox.claim.return_value = claim_result
+        outbox.mark_delivered = AsyncMock()
+
+        instrumentation = RecordingOutboxInstrumentation()
+        handler = DummyHandler(processed_events=[])
+        container = make_mock_container(outbox, handler=handler, instrumentation=instrumentation)
+
+        worker = Worker(DummyHandler)
+        worker.set_container(container)
+
+        await worker._poll_once()
+
+        assert len(instrumentation.calls) == 1
+        cg, status, retry_count, duration = instrumentation.calls[0]
+        assert cg == "DummyHandler"
+        assert status == DeliveryStatus.DELIVERED
+        assert retry_count == 2
+        assert duration >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_skip_emits_skipped_and_delivered(self):
+        from osa.domain.shared.error import SkippedEvents
+        from osa.infrastructure.event.worker import Worker
+
+        keep = DummyEvent(id=EventId(uuid4()), data="keep")
+        drop = DummyEvent(id=EventId(uuid4()), data="drop")
+        claim_result = ClaimResult(
+            deliveries=[
+                Delivery(id="del-keep", event=keep),
+                Delivery(id="del-drop", event=drop),
+            ],
+            claimed_at=datetime.now(UTC),
+        )
+        outbox = AsyncMock(spec=Outbox)
+        outbox.claim.return_value = claim_result
+        outbox.mark_delivered = AsyncMock()
+        outbox.mark_skipped = AsyncMock()
+
+        class SkipHandler(EventHandler[DummyEvent]):
+            __batch_size__: ClassVar[int] = 10
+
+            async def handle_batch(self, events):
+                raise SkippedEvents(event_ids=[drop.id], reason="dupe")
+
+        instrumentation = RecordingOutboxInstrumentation()
+        handler = SkipHandler()
+        container = make_mock_container(outbox, handler=handler, instrumentation=instrumentation)
+
+        worker = Worker(SkipHandler)
+        worker.set_container(container)
+
+        await worker._poll_once()
+
+        emitted = sorted(c[1].value for c in instrumentation.calls)
+        assert emitted == sorted([DeliveryStatus.DELIVERED.value, DeliveryStatus.SKIPPED.value])
+
+    @pytest.mark.asyncio
+    async def test_failure_emits_failed(self):
+        from osa.infrastructure.event.worker import Worker
+
+        event = DummyEvent(id=EventId(uuid4()), data="e")
+        claim_result = ClaimResult(
+            deliveries=[Delivery(id="del-1", event=event)],
+            claimed_at=datetime.now(UTC),
+        )
+        outbox = AsyncMock(spec=Outbox)
+        outbox.claim.return_value = claim_result
+        outbox.mark_failed_with_retry = AsyncMock()
+
+        instrumentation = RecordingOutboxInstrumentation()
+        handler = FailingHandler()
+        container = make_mock_container(outbox, handler=handler, instrumentation=instrumentation)
+
+        worker = Worker(FailingHandler)
+        worker.set_container(container)
+
+        await worker._poll_once()
+
+        assert len(instrumentation.calls) == 1
+        assert instrumentation.calls[0][1] == DeliveryStatus.FAILED

--- a/server/tests/unit/infrastructure/event/test_worker_batching.py
+++ b/server/tests/unit/infrastructure/event/test_worker_batching.py
@@ -19,6 +19,14 @@ from osa.domain.shared.event import (
     EventId,
 )
 from osa.domain.shared.outbox import Outbox
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation
+
+
+class _NullOutboxInstrumentation:
+    """No-op OutboxInstrumentation for tests that don't assert on metrics."""
+
+    def delivery_completed(self, *, consumer_group, status, retry_count, duration_s) -> None:  # noqa: ANN001
+        pass
 
 
 class DummyEvent(Event):
@@ -42,6 +50,8 @@ def make_mock_container(
     async def get_dependency(cls):
         if cls == Outbox:
             return outbox
+        if cls == OutboxInstrumentation:
+            return _NullOutboxInstrumentation()
         if cls == AsyncSession:
             return session
         if handler is not None and (cls is type(handler) or issubclass(cls, EventHandler)):

--- a/server/tests/unit/infrastructure/event/test_worker_exhaustion.py
+++ b/server/tests/unit/infrastructure/event/test_worker_exhaustion.py
@@ -43,6 +43,7 @@ class TestWorkerOnExhaustedErrorSafety:
         delivery.id = "delivery-1"
         delivery.event = event
         delivery.retry_count = 100  # exceeds __max_retries__
+        delivery.trace_context = None  # no origin span to link
 
         claim_result = MagicMock()
         claim_result.deliveries = [delivery]
@@ -51,9 +52,17 @@ class TestWorkerOnExhaustedErrorSafety:
         outbox.claim.return_value = claim_result
 
         # Wire up the DI scope mock
+        from osa.domain.shared.port.instrumentation import OutboxInstrumentation
+
+        class _NullOutboxInstrumentation:
+            def delivery_completed(self, **kwargs: Any) -> None:
+                pass
+
         async def mock_get(t: type) -> Any:
             if t is RunIngester:
                 return handler
+            if t is OutboxInstrumentation:
+                return _NullOutboxInstrumentation()
             return outbox
 
         scope = AsyncMock()

--- a/server/tests/unit/infrastructure/persistence/test_delivery_stats.py
+++ b/server/tests/unit/infrastructure/persistence/test_delivery_stats.py
@@ -1,0 +1,189 @@
+"""Unit tests for the outbox delivery-health aggregation query.
+
+Exercises ``SQLAlchemyEventRepository.delivery_stats`` against an in-memory
+SQLite engine (events + deliveries tables only):
+- an empty database yields no counts and no pending lag,
+- counts are keyed exactly by ``(consumer_group, DeliveryStatus)``,
+- only *eligible* pending deliveries (``deliver_after`` NULL or in the past)
+  contribute to ``oldest_pending_created_at`` — scheduled-for-later rows are
+  excluded,
+- the returned timestamp is timezone-aware (SQLite normalization).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from osa.domain.shared.event import DeliveryStatus
+from osa.infrastructure.persistence.repository.event import SQLAlchemyEventRepository
+from osa.infrastructure.persistence.tables import deliveries_table, events_table, metadata
+
+
+@pytest.fixture
+async def sqlite_session() -> AsyncIterator[AsyncSession]:
+    """In-memory SQLite session with only the events/deliveries tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: metadata.create_all(
+                sync_conn, tables=[events_table, deliveries_table]
+            )
+        )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(
+    session: AsyncSession,
+    *,
+    consumer_group: str,
+    status: DeliveryStatus,
+    created_at: datetime,
+    deliver_after: datetime | None = None,
+) -> None:
+    """Insert one event and its delivery row with fully controlled fields."""
+    event_id = str(uuid4())
+    await session.execute(
+        insert(events_table).values(
+            id=event_id,
+            event_type="TraceEvent",
+            payload={"id": event_id, "data": "x"},
+            created_at=created_at,
+            trace_context=None,
+        )
+    )
+    await session.execute(
+        insert(deliveries_table).values(
+            id=str(uuid4()),
+            event_id=event_id,
+            consumer_group=consumer_group,
+            status=status.value,
+            retry_count=0,
+            deliver_after=deliver_after,
+            updated_at=created_at,
+        )
+    )
+
+
+@pytest.mark.asyncio
+class TestDeliveryStats:
+    async def test_empty_db_yields_no_counts_and_no_lag(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+
+        stats = await repo.delivery_stats()
+
+        assert stats.counts == {}
+        assert stats.oldest_pending_created_at is None
+
+    async def test_counts_keyed_by_group_and_status(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        now = datetime.now(UTC)
+
+        await _seed(
+            sqlite_session, consumer_group="g1", status=DeliveryStatus.PENDING, created_at=now
+        )
+        await _seed(
+            sqlite_session, consumer_group="g1", status=DeliveryStatus.PENDING, created_at=now
+        )
+        await _seed(
+            sqlite_session, consumer_group="g1", status=DeliveryStatus.DELIVERED, created_at=now
+        )
+        await _seed(
+            sqlite_session, consumer_group="g2", status=DeliveryStatus.FAILED, created_at=now
+        )
+        await sqlite_session.commit()
+
+        stats = await repo.delivery_stats()
+
+        assert stats.counts == {
+            ("g1", DeliveryStatus.PENDING): 2,
+            ("g1", DeliveryStatus.DELIVERED): 1,
+            ("g2", DeliveryStatus.FAILED): 1,
+        }
+
+    async def test_future_deliver_after_excluded_from_lag(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        now = datetime.now(UTC)
+
+        # Earliest event, but scheduled for the future -> ineligible, must NOT count.
+        await _seed(
+            sqlite_session,
+            consumer_group="g1",
+            status=DeliveryStatus.PENDING,
+            created_at=now - timedelta(hours=2),
+            deliver_after=now + timedelta(hours=1),
+        )
+        # Eligible: past deliver_after.
+        await _seed(
+            sqlite_session,
+            consumer_group="g1",
+            status=DeliveryStatus.PENDING,
+            created_at=now - timedelta(minutes=30),
+            deliver_after=now - timedelta(minutes=5),
+        )
+        # Eligible: NULL deliver_after, oldest eligible event.
+        await _seed(
+            sqlite_session,
+            consumer_group="g2",
+            status=DeliveryStatus.PENDING,
+            created_at=now - timedelta(minutes=45),
+            deliver_after=None,
+        )
+        await sqlite_session.commit()
+
+        stats = await repo.delivery_stats()
+
+        assert stats.oldest_pending_created_at is not None
+        # Oldest eligible is the NULL-deliver_after row at now-45m,
+        # NOT the future-scheduled now-2h row.
+        expected = now - timedelta(minutes=45)
+        delta = abs((stats.oldest_pending_created_at - expected).total_seconds())
+        assert delta < 1.0
+
+    async def test_returned_timestamp_is_timezone_aware(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        now = datetime.now(UTC)
+
+        await _seed(
+            sqlite_session,
+            consumer_group="g1",
+            status=DeliveryStatus.PENDING,
+            created_at=now - timedelta(minutes=10),
+        )
+        await sqlite_session.commit()
+
+        stats = await repo.delivery_stats()
+
+        assert stats.oldest_pending_created_at is not None
+        assert stats.oldest_pending_created_at.tzinfo is not None
+
+    async def test_non_pending_never_contributes_to_lag(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        now = datetime.now(UTC)
+
+        # Only non-pending rows -> no eligible pending -> no lag.
+        await _seed(
+            sqlite_session,
+            consumer_group="g1",
+            status=DeliveryStatus.DELIVERED,
+            created_at=now - timedelta(hours=3),
+        )
+        await _seed(
+            sqlite_session,
+            consumer_group="g1",
+            status=DeliveryStatus.FAILED,
+            created_at=now - timedelta(hours=4),
+        )
+        await sqlite_session.commit()
+
+        stats = await repo.delivery_stats()
+
+        assert stats.oldest_pending_created_at is None

--- a/server/tests/unit/infrastructure/persistence/test_event_trace_context.py
+++ b/server/tests/unit/infrastructure/persistence/test_event_trace_context.py
@@ -1,0 +1,124 @@
+"""Unit tests for W3C trace-context capture through the outbox.
+
+Exercises SQLAlchemyEventRepository against an in-memory SQLite engine:
+- the traceparent of the appending operation is captured on the events row
+  and rehydrated onto the claimed Delivery (round-trip),
+- non-instrumented contexts (no active span) leave the column NULL,
+- the DeliveryStatus vocabulary round-trips its known string values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from opentelemetry import context as otel_context
+from opentelemetry import trace as otel_trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from osa.domain.shared.event import Delivery, DeliveryStatus, Event, EventId
+from osa.infrastructure.persistence.repository.event import SQLAlchemyEventRepository
+from osa.infrastructure.persistence.tables import deliveries_table, events_table, metadata
+
+CONSUMER_GROUP = "test-group"
+_TRACE_ID = 0x1234567890ABCDEF1234567890ABCDEF
+_SPAN_ID = 0x1A2B3C4D5E6F7788
+
+
+class TraceEvent(Event):
+    """Test event type for trace-context round-trips."""
+
+    id: EventId
+    data: str
+
+
+@pytest.fixture
+async def sqlite_session() -> AsyncIterator[AsyncSession]:
+    """In-memory SQLite session with only the events/deliveries tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: metadata.create_all(
+                sync_conn, tables=[events_table, deliveries_table]
+            )
+        )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        yield session
+    await engine.dispose()
+
+
+def _sampled_span_token() -> object:
+    """Attach a deterministic, sampled current span (no tracer SDK needed)."""
+    sc = SpanContext(
+        trace_id=_TRACE_ID,
+        span_id=_SPAN_ID,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    return otel_context.attach(otel_trace.set_span_in_context(NonRecordingSpan(sc)))
+
+
+@pytest.mark.asyncio
+class TestTraceContextRoundTrip:
+    async def test_traceparent_captured_and_rehydrated(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        event = TraceEvent(id=EventId(uuid4()), data="traced")
+
+        token = _sampled_span_token()
+        try:
+            await repo.save_with_deliveries(event, {CONSUMER_GROUP})
+        finally:
+            otel_context.detach(token)
+        await sqlite_session.commit()
+
+        result = await repo.claim_delivery(
+            consumer_group=CONSUMER_GROUP, event_types=["TraceEvent"], limit=1
+        )
+        await sqlite_session.commit()
+
+        assert len(result) == 1
+        delivery = result.deliveries[0]
+        assert delivery.trace_context is not None
+        # W3C traceparent: 00-<32 hex trace id>-<16 hex span id>-<flags>
+        parts = delivery.trace_context.split("-")
+        assert len(parts) == 4
+        assert parts[0] == "00"
+        assert parts[1] == f"{_TRACE_ID:032x}"
+        assert parts[3] == "01"  # sampled
+
+    async def test_no_span_leaves_trace_context_null(self, sqlite_session: AsyncSession):
+        repo = SQLAlchemyEventRepository(sqlite_session)
+        event = TraceEvent(id=EventId(uuid4()), data="untraced")
+
+        # No active recording span (CLI/cron path).
+        await repo.save_with_deliveries(event, {CONSUMER_GROUP})
+        await sqlite_session.commit()
+
+        result = await repo.claim_delivery(
+            consumer_group=CONSUMER_GROUP, event_types=["TraceEvent"], limit=1
+        )
+        await sqlite_session.commit()
+
+        assert len(result) == 1
+        assert result.deliveries[0].trace_context is None
+
+
+class TestDeliveryStatusEnum:
+    def test_known_values_round_trip(self) -> None:
+        expected = {
+            "pending": DeliveryStatus.PENDING,
+            "claimed": DeliveryStatus.CLAIMED,
+            "delivered": DeliveryStatus.DELIVERED,
+            "failed": DeliveryStatus.FAILED,
+            "skipped": DeliveryStatus.SKIPPED,
+        }
+        for value, member in expected.items():
+            assert member.value == value
+            assert DeliveryStatus(value) is member
+
+    def test_default_delivery_trace_context_is_none(self) -> None:
+        event = TraceEvent(id=EventId(uuid4()), data="x")
+        assert Delivery(id="d-1", event=event).trace_context is None

--- a/server/tests/unit/infrastructure/telemetry/test_adapters.py
+++ b/server/tests/unit/infrastructure/telemetry/test_adapters.py
@@ -1,0 +1,179 @@
+"""Unit tests for the OTel instrumentation adapters.
+
+Pure OpenTelemetry — no logfire. Each adapter is driven against an in-memory
+meter provider, then the exported metric points are asserted for name, labels,
+and value. This is the red-first spec for the adapters.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    Histogram,
+    InMemoryMetricReader,
+    Metric,
+    Sum,
+)
+
+from osa.domain.ingest.model.ingest_run import IngestStatus
+from osa.domain.shared.event import DeliveryStatus
+from osa.domain.shared.failure import DecisionKind, FailureKind
+from osa.domain.shared.model.hook import HookName
+from osa.domain.validation.model.hook_run import HookRunStatus
+from osa.infrastructure.telemetry.api import ApiInstrumentation
+from osa.infrastructure.telemetry.hook import OtelHookInstrumentation
+from osa.infrastructure.telemetry.ingest import OtelIngestInstrumentation
+from osa.infrastructure.telemetry.outbox import OtelOutboxInstrumentation
+
+
+@pytest.fixture
+def reader() -> InMemoryMetricReader:
+    return InMemoryMetricReader()
+
+
+@pytest.fixture
+def meter(reader: InMemoryMetricReader):
+    provider = MeterProvider(metric_readers=[reader])
+    return provider.get_meter("test")
+
+
+def _metrics(reader: InMemoryMetricReader) -> Iterator[Metric]:
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            yield from sm.metrics
+
+
+def _by_name(reader: InMemoryMetricReader, name: str) -> Metric:
+    for metric in _metrics(reader):
+        if metric.name == name:
+            return metric
+    raise AssertionError(f"metric {name!r} not exported; saw {[m.name for m in _metrics(reader)]}")
+
+
+def _points(reader: InMemoryMetricReader, name: str) -> list[tuple[dict[str, object], object]]:
+    metric = _by_name(reader, name)
+    assert isinstance(metric.data, (Sum, Histogram))
+    return [(dict(p.attributes), p) for p in metric.data.data_points]
+
+
+# ── Hook adapter ──────────────────────────────────────────────────────────────
+
+
+def test_hook_run_finished_counts_by_hook_and_status(reader, meter):
+    instr = OtelHookInstrumentation(meter)
+    hook = HookName("qc")
+
+    instr.run_finished(hook=hook, status=HookRunStatus.PASSED, duration_s=1.5, oom_retries=0)
+    instr.run_finished(hook=hook, status=HookRunStatus.FAILED, duration_s=0.5, oom_retries=0)
+
+    points = {tuple(sorted(a.items())): p.value for a, p in _points(reader, "osa_hook_runs_total")}
+    assert points[(("hook", "qc"), ("status", "passed"))] == 1
+    assert points[(("hook", "qc"), ("status", "failed"))] == 1
+
+
+def test_hook_duration_histogram_records_sum(reader, meter):
+    instr = OtelHookInstrumentation(meter)
+    instr.run_finished(
+        hook=HookName("qc"), status=HookRunStatus.PASSED, duration_s=2.0, oom_retries=0
+    )
+
+    (attrs, point) = _points(reader, "osa_hook_run_duration_seconds")[0]
+    assert attrs == {"hook": "qc", "status": "passed"}
+    assert point.sum == pytest.approx(2.0)
+
+
+def test_hook_oom_retries_only_emitted_when_positive(reader, meter):
+    instr = OtelHookInstrumentation(meter)
+    instr.run_finished(
+        hook=HookName("qc"), status=HookRunStatus.PASSED, duration_s=1.0, oom_retries=0
+    )
+    # No datapoint yet — counter never touched.
+    with pytest.raises(AssertionError):
+        _by_name(reader, "osa_hook_oom_retries_total")
+
+    instr.run_finished(
+        hook=HookName("qc"), status=HookRunStatus.PASSED, duration_s=1.0, oom_retries=3
+    )
+    (attrs, point) = _points(reader, "osa_hook_oom_retries_total")[0]
+    assert attrs == {"hook": "qc"}
+    assert point.value == 3
+
+
+def test_hook_failure_decided_labels(reader, meter):
+    instr = OtelHookInstrumentation(meter)
+    instr.run_failure_decided(
+        hook=HookName("qc"), kind=FailureKind.OOM, decision=DecisionKind.RETRY_WITH_MORE_MEMORY
+    )
+    (attrs, point) = _points(reader, "osa_hook_failures_total")[0]
+    assert attrs == {"hook": "qc", "kind": "oom", "decision": "retry_with_more_memory"}
+    assert point.value == 1
+
+
+# ── Ingest adapter ────────────────────────────────────────────────────────────
+
+
+def test_ingest_batch_completed_counts_and_publishes(reader, meter):
+    instr = OtelIngestInstrumentation(meter)
+    instr.batch_completed(published_count=42)
+
+    (attrs, point) = _points(reader, "osa_ingest_batches_total")[0]
+    assert attrs == {"outcome": "completed", "kind": "none"}
+    assert point.value == 1
+
+    (_, published) = _points(reader, "osa_records_published_total")[0]
+    assert published.value == 42
+
+
+def test_ingest_batch_failed_outcome_label(reader, meter):
+    instr = OtelIngestInstrumentation(meter)
+    instr.batch_failed(kind=FailureKind.UPSTREAM)
+
+    (attrs, point) = _points(reader, "osa_ingest_batches_total")[0]
+    assert attrs == {"outcome": "failed", "kind": "upstream"}
+    assert point.value == 1
+
+
+def test_ingest_run_finished_kind_none_maps_to_none_label(reader, meter):
+    instr = OtelIngestInstrumentation(meter)
+    instr.run_finished(status=IngestStatus.COMPLETED, kind=None)
+    instr.run_finished(status=IngestStatus.FAILED, kind=FailureKind.IMAGE_PULL)
+
+    points = {
+        tuple(sorted(a.items())): p.value for a, p in _points(reader, "osa_ingest_runs_total")
+    }
+    assert points[(("kind", "none"), ("status", "completed"))] == 1
+    assert points[(("kind", "image_pull"), ("status", "failed"))] == 1
+
+
+# ── Outbox adapter ────────────────────────────────────────────────────────────
+
+
+def test_outbox_delivery_completed_counter_and_histogram(reader, meter):
+    instr = OtelOutboxInstrumentation(meter)
+    instr.delivery_completed(
+        consumer_group="RunHooks", status=DeliveryStatus.DELIVERED, retry_count=0, duration_s=0.25
+    )
+
+    (attrs, point) = _points(reader, "osa_deliveries_total")[0]
+    assert attrs == {"consumer_group": "RunHooks", "status": "delivered"}
+    assert point.value == 1
+
+    (h_attrs, h_point) = _points(reader, "osa_dispatch_duration_seconds")[0]
+    assert h_attrs == {"consumer_group": "RunHooks"}
+    assert h_point.sum == pytest.approx(0.25)
+
+
+# ── API adapter ───────────────────────────────────────────────────────────────
+
+
+def test_api_unhandled_error_counter(reader, meter):
+    instr = ApiInstrumentation(meter)
+    instr.unhandled_error()
+    instr.unhandled_error()
+
+    (_, point) = _points(reader, "osa_unhandled_errors_total")[0]
+    assert point.value == 2

--- a/server/tests/unit/infrastructure/telemetry/test_bootstrap.py
+++ b/server/tests/unit/infrastructure/telemetry/test_bootstrap.py
@@ -145,3 +145,53 @@ def test_otlp_without_token_sends_no_auth_header(recorder: _Recorder) -> None:
     ]
     span_exp = _span_exporter(span_procs[0])
     assert "Authorization" not in span_exp._session.headers  # noqa: SLF001
+
+
+# ── Prometheus-compatible histogram views (regression: #158 smoke test) ──────
+#
+# prometheus-exporter 0.60b1 crashes on ExponentialHistogramDataPoint at
+# collection time, and logfire's DEFAULT_VIEWS aggregate every histogram
+# exponentially. The bootstrap must swap in explicit buckets whenever the pull
+# endpoint is enabled — otherwise the first scrape after any histogram record
+# (e.g. one instrumented HTTP request) returns a 500.
+
+
+def test_views_keep_logfire_defaults_when_prometheus_disabled() -> None:
+    views = TelemetryBootstrap._metric_views(prometheus_enabled=False)
+    assert views == list(setup_mod.logfire.MetricsOptions.DEFAULT_VIEWS)
+
+
+def test_views_replace_exponential_histograms_when_prometheus_enabled() -> None:
+    from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation
+
+    views = TelemetryBootstrap._metric_views(prometheus_enabled=True)
+    assert not any(
+        isinstance(getattr(v, "_aggregation", None), ExponentialBucketHistogramAggregation)
+        for v in views
+    )
+    # The non-histogram defaults (active_requests attribute filtering) survive.
+    assert len(views) == len(setup_mod.logfire.MetricsOptions.DEFAULT_VIEWS)
+
+
+def test_histogram_records_render_through_prometheus_reader() -> None:
+    """End-to-end: a recorded histogram must survive a Prometheus collection."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from prometheus_client import CollectorRegistry, generate_latest
+
+    from osa.infrastructure.telemetry.setup import _OwnedRegistryPrometheusReader
+
+    registry = CollectorRegistry()
+    reader = _OwnedRegistryPrometheusReader(registry)
+    provider = MeterProvider(
+        metric_readers=[reader],
+        views=TelemetryBootstrap._metric_views(prometheus_enabled=True),
+    )
+    try:
+        meter = provider.get_meter("osa-test")
+        histogram = meter.create_histogram("osa_test_duration_seconds", unit="s")
+        histogram.record(0.25, {"hook": "demo"})
+
+        exposition = generate_latest(registry).decode()
+        assert "osa_test_duration_seconds" in exposition
+    finally:
+        provider.shutdown()

--- a/server/tests/unit/infrastructure/telemetry/test_bootstrap.py
+++ b/server/tests/unit/infrastructure/telemetry/test_bootstrap.py
@@ -1,0 +1,147 @@
+"""Unit tests for TelemetryBootstrap.
+
+logfire.configure is monkeypatched to a recording stub so we can assert what the
+bootstrap *would* configure (readers, span/log processors, exporter endpoints
+and headers) without touching process-global provider state.
+"""
+
+from typing import Any
+
+import pytest
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic import SecretStr
+
+from osa.config import Config
+from osa.infrastructure.telemetry import setup as setup_mod
+from osa.infrastructure.telemetry.setup import TelemetryBootstrap
+
+
+class _Recorder:
+    """Records the kwargs passed to logfire.configure."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    rec = _Recorder()
+    monkeypatch.setattr(setup_mod.logfire, "configure", rec)
+    # LogfireLoggingHandler() must be constructible without a real configure.
+    return rec
+
+
+def _config(**observability: Any) -> Config:
+    return Config(
+        base_url="http://localhost:8000",
+        observability=observability,  # type: ignore[arg-type]  # pydantic coerces dict
+    )
+
+
+def _span_exporter(processor: BatchSpanProcessor):
+    return processor._batch_processor._exporter  # noqa: SLF001
+
+
+def _log_exporter(processor: BatchLogRecordProcessor):
+    return processor._batch_processor._exporter  # noqa: SLF001
+
+
+def _metric_exporter(reader: PeriodicExportingMetricReader):
+    return reader._exporter  # noqa: SLF001
+
+
+def test_configure_is_idempotent(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config())
+    boot.configure(_config())
+    assert len(recorder.calls) == 1
+
+
+def test_prometheus_disabled_no_reader_no_registry(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config(prometheus_enabled=False))
+
+    readers = recorder.calls[0]["metrics"].additional_readers
+    assert not any(isinstance(r, PrometheusMetricReader) for r in readers)
+    assert boot.prometheus_registry is None
+
+
+def test_prometheus_enabled_owns_registry(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config(prometheus_enabled=True))
+
+    readers = recorder.calls[0]["metrics"].additional_readers
+    assert any(isinstance(r, PrometheusMetricReader) for r in readers)
+    assert boot.prometheus_registry is not None
+
+
+def test_sampling_head_rate_passed_through(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config(trace_sample_rate=0.25))
+    assert recorder.calls[0]["sampling"].head == pytest.approx(0.25)
+
+
+def test_no_otlp_means_no_advanced_and_no_push_exporters(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config(prometheus_enabled=False))
+    call = recorder.calls[0]
+
+    assert call["advanced"] is None
+    assert not any(isinstance(p, BatchSpanProcessor) for p in call["additional_span_processors"])
+    assert call["metrics"].additional_readers == []
+
+
+def test_otlp_endpoint_wires_all_three_signals_with_auth(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(
+        _config(
+            otlp_endpoint="https://collector.example/",  # trailing slash must be stripped
+            otlp_token=SecretStr("s3cret"),
+            prometheus_enabled=False,
+        )
+    )
+    call = recorder.calls[0]
+
+    # Traces
+    span_procs = [
+        p for p in call["additional_span_processors"] if isinstance(p, BatchSpanProcessor)
+    ]
+    assert len(span_procs) == 1
+    span_exp = _span_exporter(span_procs[0])
+    assert span_exp._endpoint == "https://collector.example/v1/traces"  # noqa: SLF001
+    assert span_exp._session.headers["Authorization"] == "Bearer s3cret"  # noqa: SLF001
+
+    # Metrics
+    metric_readers = [
+        r
+        for r in call["metrics"].additional_readers
+        if isinstance(r, PeriodicExportingMetricReader)
+    ]
+    assert len(metric_readers) == 1
+    metric_exp = _metric_exporter(metric_readers[0])
+    assert metric_exp._endpoint == "https://collector.example/v1/metrics"  # noqa: SLF001
+    assert metric_exp._session.headers["Authorization"] == "Bearer s3cret"  # noqa: SLF001
+
+    # Logs
+    log_procs = call["advanced"].log_record_processors
+    assert len(log_procs) == 1
+    log_exp = _log_exporter(log_procs[0])
+    assert log_exp._endpoint == "https://collector.example/v1/logs"  # noqa: SLF001
+    assert log_exp._session.headers["Authorization"] == "Bearer s3cret"  # noqa: SLF001
+
+
+def test_otlp_without_token_sends_no_auth_header(recorder: _Recorder) -> None:
+    boot = TelemetryBootstrap()
+    boot.configure(_config(otlp_endpoint="https://collector.example", prometheus_enabled=False))
+    call = recorder.calls[0]
+    span_procs = [
+        p for p in call["additional_span_processors"] if isinstance(p, BatchSpanProcessor)
+    ]
+    span_exp = _span_exporter(span_procs[0])
+    assert "Authorization" not in span_exp._session.headers  # noqa: SLF001

--- a/server/tests/unit/infrastructure/telemetry/test_di.py
+++ b/server/tests/unit/infrastructure/telemetry/test_di.py
@@ -1,0 +1,54 @@
+"""Unit tests for TelemetryProvider DI wiring.
+
+The container resolves each instrumentation port to its OTel adapter and the
+Meter as an APP-scoped singleton.
+"""
+
+import asyncio
+import os
+
+from opentelemetry.metrics import Meter
+
+os.environ.setdefault("OSA_AUTH__JWT__SECRET", "test-secret-that-is-at-least-32-characters-long")
+os.environ.setdefault("OSA_BASE_URL", "http://localhost:8000")
+
+from osa.application.di import create_container  # noqa: E402
+from osa.domain.ingest.port.instrumentation import IngestInstrumentation  # noqa: E402
+from osa.domain.shared.port.instrumentation import OutboxInstrumentation  # noqa: E402
+from osa.domain.validation.port.instrumentation import HookInstrumentation  # noqa: E402
+from osa.infrastructure.telemetry.api import ApiInstrumentation  # noqa: E402
+from osa.infrastructure.telemetry.hook import OtelHookInstrumentation  # noqa: E402
+from osa.infrastructure.telemetry.ingest import OtelIngestInstrumentation  # noqa: E402
+from osa.infrastructure.telemetry.outbox import OtelOutboxInstrumentation  # noqa: E402
+
+
+def test_ports_resolve_to_otel_adapters() -> None:
+    container = create_container()
+
+    async def resolve():
+        hook = await container.get(HookInstrumentation)
+        ingest = await container.get(IngestInstrumentation)
+        outbox = await container.get(OutboxInstrumentation)
+        api = await container.get(ApiInstrumentation)
+        meter = await container.get(Meter)
+        return hook, ingest, outbox, api, meter
+
+    hook, ingest, outbox, api, meter = asyncio.run(resolve())
+
+    assert isinstance(hook, OtelHookInstrumentation)
+    assert isinstance(ingest, OtelIngestInstrumentation)
+    assert isinstance(outbox, OtelOutboxInstrumentation)
+    assert isinstance(api, ApiInstrumentation)
+    assert isinstance(meter, Meter)
+
+
+def test_instrumentation_is_app_scoped_singleton() -> None:
+    container = create_container()
+
+    async def resolve():
+        first = await container.get(HookInstrumentation)
+        second = await container.get(HookInstrumentation)
+        return first, second
+
+    first, second = asyncio.run(resolve())
+    assert first is second

--- a/server/tests/unit/infrastructure/telemetry/test_sampler.py
+++ b/server/tests/unit/infrastructure/telemetry/test_sampler.py
@@ -1,0 +1,290 @@
+"""Unit tests for the periodic :class:`TelemetrySampler`.
+
+The sampler bridges async periodic sampling (outbox delivery health, DB pool
+stats, worker states) to *sync* OpenTelemetry observable-gauge callbacks. These
+tests drive it against an in-memory meter provider and assert the exported gauge
+points for name, labels, and value — the red-first spec for P6.
+"""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    Gauge,
+    InMemoryMetricReader,
+    Metric,
+)
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from osa.domain.shared.event import DeliveryStats, DeliveryStatus, WorkerStatus
+from osa.domain.shared.port.event_repository import EventRepository
+from osa.infrastructure.telemetry.sampler import (
+    PoolStats,
+    SamplerSnapshot,
+    TelemetrySampler,
+)
+
+
+@pytest.fixture
+def reader() -> InMemoryMetricReader:
+    return InMemoryMetricReader()
+
+
+@pytest.fixture
+def meter(reader: InMemoryMetricReader):
+    provider = MeterProvider(metric_readers=[reader])
+    return provider.get_meter("test")
+
+
+def _metrics(reader: InMemoryMetricReader) -> Iterator[Metric]:
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            yield from sm.metrics
+
+
+def _points(reader: InMemoryMetricReader, name: str) -> list[tuple[dict[str, object], object]]:
+    for metric in _metrics(reader):
+        if metric.name == name:
+            assert isinstance(metric.data, Gauge)
+            return [(dict(p.attributes), p.value) for p in metric.data.data_points]
+    return []
+
+
+@dataclass
+class _FakeRepo:
+    """EventRepository stub exposing only ``delivery_stats``."""
+
+    stats: DeliveryStats
+
+    async def delivery_stats(self) -> DeliveryStats:
+        return self.stats
+
+
+def _make_container(repo: object) -> MagicMock:
+    """Mock DI container whose UOW scope resolves ``EventRepository`` to ``repo``."""
+
+    async def get_dependency(cls):
+        if cls is EventRepository:
+            return repo
+        raise AssertionError(f"unexpected dependency requested: {cls!r}")
+
+    scope = AsyncMock()
+    scope.get = AsyncMock(side_effect=get_dependency)
+
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=scope)
+    context.__aexit__ = AsyncMock(return_value=None)
+
+    container = MagicMock()
+    container.return_value = context
+    return container
+
+
+def _fake_worker(status: WorkerStatus) -> object:
+    """Minimal object exposing ``.state.status`` like a real Worker."""
+    return SimpleNamespace(state=SimpleNamespace(status=status))
+
+
+def _pg_engine():
+    """A QueuePool-backed engine (never connects) so pool gauges are populated."""
+    return create_async_engine("postgresql+asyncpg://u:p@localhost/db")
+
+
+def _sqlite_engine():
+    """A StaticPool-backed engine so pool stats are absent."""
+    return create_async_engine("sqlite+aiosqlite:///:memory:")
+
+
+# ── Fresh sampler (no refresh) ────────────────────────────────────────────────
+
+
+def test_fresh_sampler_emits_zeroes_and_no_pool(reader, meter):
+    TelemetrySampler(meter, _pg_engine())
+
+    assert _points(reader, "osa_outbox_lag_seconds") == [({}, 0.0)]
+    assert _points(reader, "osa_outbox_pending") == []
+    assert _points(reader, "osa_outbox_failed") == []
+    assert _points(reader, "osa_db_pool_checked_out") == []
+    assert _points(reader, "osa_db_pool_size") == []
+    assert _points(reader, "osa_db_pool_overflow") == []
+    assert _points(reader, "osa_workers_busy") == [({}, 0)]
+    assert _points(reader, "osa_workers_total") == [({}, 0)]
+
+
+# ── After a good refresh ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_populates_all_gauges(reader, meter):
+    sampler = TelemetrySampler(meter, _pg_engine())
+
+    oldest = datetime.now(UTC) - timedelta(seconds=12)
+    stats = DeliveryStats(
+        counts={
+            ("RunHooks", DeliveryStatus.PENDING): 3,
+            ("PublishBatch", DeliveryStatus.PENDING): 1,
+            ("RunHooks", DeliveryStatus.FAILED): 2,
+            ("RunHooks", DeliveryStatus.DELIVERED): 99,
+        },
+        oldest_pending_created_at=oldest,
+    )
+    container = _make_container(_FakeRepo(stats))
+    workers = [
+        _fake_worker(WorkerStatus.PROCESSING),
+        _fake_worker(WorkerStatus.PROCESSING),
+        _fake_worker(WorkerStatus.IDLE),
+    ]
+
+    await sampler.refresh(container, workers)
+
+    (lag_attrs, lag_val) = _points(reader, "osa_outbox_lag_seconds")[0]
+    assert lag_attrs == {}
+    assert lag_val == pytest.approx(12.0, abs=2.0)
+
+    pending = {a["consumer_group"]: v for a, v in _points(reader, "osa_outbox_pending")}
+    assert pending == {"RunHooks": 3, "PublishBatch": 1}
+
+    failed = {a["consumer_group"]: v for a, v in _points(reader, "osa_outbox_failed")}
+    assert failed == {"RunHooks": 2}
+
+    assert _points(reader, "osa_workers_busy") == [({}, 2)]
+    assert _points(reader, "osa_workers_total") == [({}, 3)]
+
+    # QueuePool → pool gauges present (single unlabelled point each).
+    assert len(_points(reader, "osa_db_pool_size")) == 1
+    assert len(_points(reader, "osa_db_pool_checked_out")) == 1
+    assert len(_points(reader, "osa_db_pool_overflow")) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_no_pending_reports_zero_lag(reader, meter):
+    sampler = TelemetrySampler(meter, _pg_engine())
+    stats = DeliveryStats(counts={}, oldest_pending_created_at=None)
+    container = _make_container(_FakeRepo(stats))
+
+    await sampler.refresh(container, [])
+
+    assert _points(reader, "osa_outbox_lag_seconds") == [({}, 0.0)]
+
+
+# ── SQLite StaticPool → no pool gauges ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_static_pool_yields_no_pool_gauges(reader, meter):
+    sampler = TelemetrySampler(meter, _sqlite_engine())
+    stats = DeliveryStats(counts={}, oldest_pending_created_at=None)
+    container = _make_container(_FakeRepo(stats))
+
+    await sampler.refresh(container, [])
+
+    assert sampler._snapshot.pool is None
+    assert _points(reader, "osa_db_pool_checked_out") == []
+    assert _points(reader, "osa_db_pool_size") == []
+    assert _points(reader, "osa_db_pool_overflow") == []
+
+
+# ── Refresh error keeps the last good snapshot ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_keeps_previous_snapshot(meter, monkeypatch):
+    import osa.infrastructure.telemetry.sampler as sampler_module
+
+    fake_logger = MagicMock()
+    monkeypatch.setattr(sampler_module, "logger", fake_logger)
+
+    sampler = TelemetrySampler(meter, _pg_engine())
+
+    good = SamplerSnapshot(
+        outbox_lag_seconds=5.0,
+        pending_by_group={"RunHooks": 7},
+        failed_by_group={},
+        pool=PoolStats(checked_out=1, size=5, overflow=0),
+        workers_busy=1,
+        workers_total=2,
+    )
+    sampler._snapshot = good
+
+    class _BoomRepo:
+        async def delivery_stats(self) -> DeliveryStats:
+            raise RuntimeError("db down")
+
+    container = _make_container(_BoomRepo())
+
+    await sampler.refresh(container, [])
+
+    assert sampler._snapshot is good  # unchanged
+    assert fake_logger.warn.call_count == 1
+
+
+# ── WorkerPool wiring ─────────────────────────────────────────────────────────
+
+
+class _StubSampler:
+    """Records refresh calls; stands in for a real TelemetrySampler."""
+
+    def __init__(self) -> None:
+        self.refresh_calls = 0
+
+    async def refresh(self, container, workers) -> None:  # noqa: ANN001
+        self.refresh_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_without_sampler_creates_no_task():
+    from tests.unit.infrastructure.event.test_worker_pool import (
+        DummyHandler,
+        make_mock_container,
+    )
+
+    from osa.infrastructure.event.worker import WorkerPool
+
+    pool = WorkerPool(container=make_mock_container(), stale_claim_interval=0)
+    pool.register(DummyHandler)
+
+    await pool.start()
+    try:
+        assert pool._telemetry_sampler_task is None
+    finally:
+        await pool.stop()
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_with_sampler_runs_and_cancels():
+    from tests.unit.infrastructure.event.test_worker_pool import (
+        DummyHandler,
+        make_mock_container,
+    )
+
+    from osa.infrastructure.event.worker import WorkerPool
+
+    sampler = _StubSampler()
+    pool = WorkerPool(
+        container=make_mock_container(),
+        stale_claim_interval=0,
+        sampler=sampler,  # type: ignore[arg-type]
+        sampler_interval=0.02,
+    )
+    pool.register(DummyHandler)
+
+    await pool.start()
+    try:
+        assert pool._telemetry_sampler_task is not None
+        # Let the loop tick at least once.
+        import asyncio
+
+        await asyncio.sleep(0.05)
+        assert sampler.refresh_calls >= 1
+    finally:
+        await pool.stop()
+
+    assert pool._telemetry_sampler_task.done()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -999,6 +999,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
@@ -1125,6 +1139,7 @@ dependencies = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "logfire", extra = ["fastapi", "httpx"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openpyxl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-exporter-prometheus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "psycopg2-binary", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1170,6 +1185,7 @@ requires-dist = [
     { name = "kubernetes-asyncio", marker = "extra == 'k8s'", specifier = ">=31.0" },
     { name = "logfire", extras = ["fastapi", "httpx"], specifier = ">=4.15.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "opentelemetry-exporter-prometheus", specifier = "==0.60b1" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.4" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -1234,6 +1250,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements Phases 1–3 of #158: metrics, log export, end-to-end traces, and real health/readiness endpoints — one OpenTelemetry pipeline built on the existing Logfire integration, serving self-hosters (pull or push) and managed hosting (push) from the same config surface.

## What's here

**Config** — new `ObservabilityConfig` group (`OSA_OBSERVABILITY__*`): `otlp_endpoint` (+ `otlp_token` bearer auth) for OTLP/HTTP push of all three signals, `prometheus_enabled` (default on) for the pull endpoint, `trace_sample_rate` head sampling. Identity resource attributes ride the standard `OTEL_RESOURCE_ATTRIBUTES` env.

**Telemetry bootstrap** (`infrastructure/telemetry/setup.py`) — extracts the inline logfire block from `app.py` into an idempotent, configure-once `TelemetryBootstrap` (test suites build many apps per process). Owns a private Prometheus `CollectorRegistry` (never the global default), wires OTLP span/metric/log exporters when an endpoint is configured, and swaps logfire's exponential-bucket histogram views for explicit buckets whenever the Prometheus endpoint is on (the 0.60b1 exporter cannot render `ExponentialHistogramDataPoint` — caught in live smoke testing, now regression-tested).

**Instrumentation ports** — hexagonal domain probes, one small port per domain (`HookInstrumentation`, `IngestInstrumentation`, `OutboxInstrumentation`), `Port, Protocol` + `@abstractmethod` like every other port, with one `Otel*` adapter class each in `infrastructure/telemetry/`. Metric label values come only from existing enums (`HookRunStatus`, `FailureKind`, new `DecisionKind`, `IngestStatus`, new `DeliveryStatus`) so cardinality is bounded by construction. No OTel imports anywhere in `domain/`.

**Emission** — hook runs (count/duration/failure-decision), ingest batches + terminal runs, outbox delivery attempts + dispatch duration, API unhandled errors. HTTP latency/throughput comes free from the existing logfire FastAPI instrumentation.

**Gauges** — a `TelemetrySampler` loop in the `WorkerPool` (15s, same lifecycle as the stale-claim cleanup) projects levels into observable gauges: outbox lag (oldest *eligible* pending delivery), pending/failed backlog per consumer group (new `EventRepository.delivery_stats()` — one indexed GROUP BY), DB pool occupancy, live worker counts.

**Traces across the outbox** — `events.trace_context` (nullable, W3C traceparent) is captured at append time in the event repository and resumed in the worker as **span links** on a `worker.dispatch` span (links, not parent: a batch can mix events from several requests). Events appended *during* handling capture the dispatch span, so multi-hop chains (`submit → RunHooks → PublishBatch → …`) reconnect end-to-end. Missing/malformed traceparents cost one link, never a dispatch.

**Endpoints** — `GET /metrics` (Prometheus exposition, root-mounted, 404 when disabled); `GET /api/v1/health` rewritten (real `config.version` — was hardcoded `0.1.0`); new `GET /api/v1/ready` with per-component checks (db `SELECT 1`, worker-pool liveness, k8s runner health; OCI runner reported `unchecked`, neutral) returning 200/503.

**Docs** — `docs/observability.md`: config reference, Prometheus/OTLP quick starts, full metric reference with label vocabularies, health contract, trace model, security notes.

## Verification

- 1371 unit + 37 contract tests green (TDD per package; every emission site, the view swap, registry ownership, link extraction, and readiness degradation paths covered)
- 152 integration tests against real Postgres; `alembic check` zero-drift on a fresh PG migrate
- Live smoke: server on Postgres — `/health`, `/ready` (200, all components), `/metrics` showing `osa_*` gauges and HTTP histograms after traffic
- `ruff` + `ty` clean; pre-commit (incl. unit-test hook) green on every commit

Part of #158 — the cloud-side collector/dashboards (Phase 4) live in opensciencearchive/cloud#40.
