### PR TITLE
feat: prebuilt Grafana dashboard + alert rules for observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       server: ${{ steps.filter.outputs.server }}
       web: ${{ steps.filter.outputs.web }}
       widgets: ${{ steps.filter.outputs.widgets }}
+      observability: ${{ steps.filter.outputs.observability }}
     steps:
       - uses: actions/checkout@v6
 
@@ -32,6 +33,8 @@ jobs:
               - 'web/**'
             widgets:
               - 'packages/osa-widgets/**'
+            observability:
+              - 'deploy/observability/**'
 
   # Server (Python backend) checks
   server-lint:
@@ -219,6 +222,24 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+  # Observability config (deploy/observability) — Grafana dashboard + alert rules
+  observability-config:
+    name: Observability - Validate Dashboard & Rules
+    needs: changes
+    if: needs.changes.outputs.observability == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate dashboard JSON
+        run: python3 -c "import json; json.load(open('deploy/observability/grafana-dashboard.json'))"
+
+      - name: Validate alert rules (promtool)
+        run: |
+          docker run --rm --entrypoint promtool \
+            -v "$PWD/deploy/observability:/work" \
+            prom/prometheus:latest check rules /work/alert-rules.yml
 
   # Widgets (MCP Apps UI bundles, packages/osa-widgets)
   widgets-test:

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -1,0 +1,72 @@
+# OSA observability — dashboard & alert rules
+
+Importable monitoring config for a self-hosted OSA node. These consume the
+metrics the node already exposes — they add **no** server-side behaviour. See
+[`docs/observability.md`](../../docs/observability.md) for the full metric
+reference, label vocabularies, health contract, and trace model.
+
+> This ships importable config, **not** a running stack. Bundling
+> Prometheus/Grafana services into `docker-compose.yml` is intentionally out of
+> scope — point your existing monitoring at the node.
+
+## Prerequisites
+
+The node must expose metrics. Either scrape the Prometheus endpoint
+(`prometheus_enabled` is on by default):
+
+```
+GET /metrics        # Prometheus exposition, root-mounted
+```
+
+or set `OSA_OBSERVABILITY__OTLP_ENDPOINT` to push metrics to your own collector.
+Metric names below follow the OpenTelemetry Prometheus exporter's normalization
+(dots → underscores, unit suffix appended).
+
+## `grafana-dashboard.json`
+
+Import into Grafana: **Dashboards → New → Import → Upload JSON file**, then pick
+your Prometheus data source when prompted (the dashboard uses a `$datasource`
+variable — no data-source UID is hardcoded). A `$hook` variable filters the
+per-hook panels.
+
+Rows: **Node health & API edge**, **Outbox & queue health**, **Workflow
+stages**, **Hook execution**, **Ingest throughput**, **Runtime resources**.
+
+## `alert-rules.yml`
+
+Prometheus alerting rules. Reference the file from your Prometheus config:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - /etc/prometheus/osa-alert-rules.yml
+```
+
+Validate before loading:
+
+```bash
+promtool check rules deploy/observability/alert-rules.yml
+```
+
+Thresholds and `for:` durations are **starting points** — tune them to your
+node's traffic and SLOs before paging on them.
+
+## Reading the metrics correctly (#160)
+
+Two footguns are baked into the rules and panels so you don't hit them:
+
+- **`osa_dispatch_duration_seconds` times a whole workflow**, not a single hop —
+  a `ProcessBatch` dispatch can span minutes to hours. For per-stage latency,
+  read the `workflow.stage` spans, not this histogram.
+- **`osa_deliveries_total{status="failed"}` counts failed *attempts*, not
+  terminal failures.** One retry budget spans the whole workflow and
+  redeliveries fast-forward past cleared stages, so attempt-failures inflate.
+  For "did a run/batch actually fail", read the domain counters
+  (`osa_ingest_runs_total{status="failed"}`,
+  `osa_ingest_batches_total{outcome="failed"}`).
+
+## Security
+
+`/metrics` is unauthenticated by design. If the node is reachable from an
+untrusted network, disable it and push OTLP instead, or shield it at your
+reverse proxy — see the security notes in `docs/observability.md`.

--- a/deploy/observability/alert-rules.yml
+++ b/deploy/observability/alert-rules.yml
@@ -1,0 +1,198 @@
+# Example Prometheus alerting rules for an OSA node.
+#
+# These are a starting point, not a turnkey policy — thresholds (lag seconds,
+# error ratios, `for:` durations) should be tuned to your node's traffic and
+# SLOs before you page on them. Load them into Prometheus via `rule_files:` (or
+# translate into Grafana-managed alerts / Alertmanager as you prefer).
+#
+# Metric names follow the OpenTelemetry Prometheus exporter's normalization:
+# dots become underscores and the unit is appended, so the OTel histogram
+# `http.server.request.duration` (seconds) is scraped as
+# `http_server_request_duration_seconds{_bucket,_count,_sum}`. If your exporter
+# or semconv version normalizes differently (e.g. an older `http.server.duration`
+# or a different status-code label), adjust the HTTP expressions below.
+#
+# See docs/observability.md for the full metric reference and label vocabularies.
+
+groups:
+  - name: osa-availability
+    rules:
+      # Push-model liveness. A node that pushes OTLP (or whose /metrics stops
+      # being scraped) cannot be seen as "down" via a failed scrape — infer it
+      # from telemetry going stale. osa_workers_total is sampled every 15s by a
+      # live node, so its absence for minutes means the node (or its worker
+      # pool) is gone.
+      - alert: OSANodeTelemetryStale
+        expr: absent_over_time(osa_workers_total[5m])
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OSA node telemetry has gone stale"
+          description: >
+            No osa_workers_total samples for 5m. The node is down, its worker
+            pool has stopped, or its telemetry export/scrape has broken. Check
+            /api/v1/ready and the process.
+
+      - alert: OSAWorkerPoolStalled
+        expr: osa_workers_total > 0 and osa_workers_busy == osa_workers_total
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Every worker loop has been busy for 10m"
+          description: >
+            osa_workers_busy has equalled osa_workers_total for 10m — the pool
+            has no free capacity. Either sustained load or a stage (hook
+            container, ingester) is parked. Correlate with osa_outbox_lag_seconds
+            and the workflow.stage spans.
+
+  - name: osa-outbox
+    rules:
+      - alert: OSAOutboxBacklogGrowing
+        expr: osa_outbox_lag_seconds > 300
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oldest eligible outbox delivery is >5m old"
+          description: >
+            osa_outbox_lag_seconds = {{ $value | humanizeDuration }} for 10m. The
+            node is falling behind on event delivery. Check worker health and
+            whether a workflow stage is stuck.
+
+      - alert: OSAOutboxBacklogCritical
+        expr: osa_outbox_lag_seconds > 1800
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oldest eligible outbox delivery is >30m old"
+          description: >
+            osa_outbox_lag_seconds = {{ $value | humanizeDuration }} for 10m —
+            deliveries are effectively not draining.
+
+      # NOTE: this reads a GAUGE of currently-failed deliveries, not the
+      # deliveries_total{status="failed"} COUNTER. Since #160 one retry budget
+      # spans a whole workflow and redeliveries fast-forward past cleared
+      # stages, so failed *attempts* inflate and are NOT terminal failures.
+      # Read terminal outcomes from the domain counters (see osa-pipeline).
+      - alert: OSAOutboxDeadLettered
+        expr: sum by (consumer_group) (osa_outbox_failed) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Deliveries stuck in failed state for {{ $labels.consumer_group }}"
+          description: >
+            osa_outbox_failed{consumer_group="{{ $labels.consumer_group }}"} =
+            {{ $value }} for 15m — deliveries have exhausted their retry budget
+            and are dead-lettered. These need operator attention; they will not
+            retry on their own.
+
+  - name: osa-pipeline
+    rules:
+      # Terminal ingest-run failures — the trustworthy "a run actually failed"
+      # signal (domain counter), unlike delivery-attempt failures.
+      - alert: OSAIngestRunsFailing
+        expr: sum(rate(osa_ingest_runs_total{status="failed"}[15m])) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Ingest runs are reaching a terminal failed state"
+          description: >
+            Read the run's failure_kind / failure_reason from GET
+            /ingestions/{id} to see the cause.
+
+      # Heuristic checkpoint-loss detector. In steady state a redelivery should
+      # SKIP every stage a durable checkpoint already cleared; an expensive
+      # stage re-running (`ran`) *while deliveries are being retried* is the
+      # smell that a stage checkpoint didn't survive and container work was
+      # repeated. This is a heuristic — confirm with the workflow.stage spans
+      # and the "Checkpoints" dashboard panel before treating it as real.
+      - alert: OSAWorkflowCheckpointLost
+        expr: |
+          (sum by (workflow, stage) (
+            rate(osa_workflow_stages_total{outcome="ran", stage=~"hooks|insert_features|publish"}[15m])
+          ) > 0)
+          and on() (sum(rate(osa_outbox_failed[15m])) > 0)
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Expensive stage {{ $labels.workflow }}/{{ $labels.stage }} re-running during retries"
+          description: >
+            An expensive workflow stage is running while deliveries are being
+            retried, which can mean a lost stage checkpoint caused container work
+            to repeat. Confirm against the workflow.stage spans.
+
+  - name: osa-hooks
+    rules:
+      # Config/permission/image failures are operator-fixable and shouldn't wait
+      # on a long window — they will never succeed on retry.
+      - alert: OSAHookInfraFailures
+        expr: sum by (hook, kind) (rate(osa_hook_failures_total{kind=~"image_pull|rbac|config"}[10m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Hook {{ $labels.hook }} failing with {{ $labels.kind }}"
+          description: >
+            A hook is failing on an operator-fixable cause (bad image reference,
+            RBAC, or config) — retries will not clear it. Fix the hook release
+            or cluster config.
+
+      - alert: OSAHookFailureRate
+        expr: |
+          sum by (hook) (rate(osa_hook_failures_total[15m]))
+          /
+          clamp_min(sum by (hook) (rate(osa_hook_runs_total[15m])), 1) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Hook {{ $labels.hook }} failing >10% of runs"
+          description: "Elevated hook failure rate over 15m. Inspect kind/decision breakdown."
+
+  - name: osa-api
+    rules:
+      - alert: OSAUnhandledErrors
+        expr: sum(rate(osa_unhandled_errors_total[5m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unhandled exceptions reaching the global error handler"
+          description: >
+            Requests are surfacing as 500s via the bare-Exception handler for
+            10m. These are bugs, not domain errors — check logs/traces.
+
+      # Label name for the status code depends on your semconv version
+      # (`http_response_status_code` in current OTel HTTP semconv).
+      - alert: OSAHighHTTPErrorRate
+        expr: |
+          sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(http_server_request_duration_seconds_count[5m])), 1) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "HTTP 5xx rate above 5%"
+          description: "More than 5% of requests are returning 5xx over 10m."
+
+  - name: osa-resources
+    rules:
+      - alert: OSADBPoolSaturated
+        expr: osa_db_pool_checked_out / clamp_min(osa_db_pool_size, 1) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SQLAlchemy connection pool >90% checked out"
+          description: >
+            osa_db_pool_checked_out is above 90% of osa_db_pool_size for 5m and
+            spilling into overflow (osa_db_pool_overflow). Requests may start
+            waiting on connections — consider raising the pool size or reducing
+            concurrency.

--- a/deploy/observability/alert-rules.yml
+++ b/deploy/observability/alert-rules.yml
@@ -151,11 +151,18 @@ groups:
             RBAC, or config) — retries will not clear it. Fix the hook release
             or cluster config.
 
+      # Natural ratio, NOT clamp_min(runs, 1): clamping a sub-1/s run rate to a
+      # floor of 1 destroys the ratio for low-volume hooks (a hook with one run
+      # and one failure in 15m has a true 100% failure ratio but would evaluate
+      # ~0.0011/1). Dividing directly means the series only exists where runs
+      # exist (denominator includes failed/error runs, which osa_hook_runs_total
+      # counts), so a fully-failing low-volume hook correctly reads 1.0, while
+      # 0/0 → NaN and absent series both yield no alert.
       - alert: OSAHookFailureRate
         expr: |
           sum by (hook) (rate(osa_hook_failures_total[15m]))
           /
-          clamp_min(sum by (hook) (rate(osa_hook_runs_total[15m])), 1) > 0.1
+          sum by (hook) (rate(osa_hook_runs_total[15m])) > 0.1
         for: 15m
         labels:
           severity: warning
@@ -178,11 +185,14 @@ groups:
 
       # Label name for the status code depends on your semconv version
       # (`http_response_status_code` in current OTel HTTP semconv).
+      # Natural ratio, NOT clamp_min(total, 1) — see OSAHookFailureRate: clamping
+      # a sub-1/s request rate would suppress a 100%-5xx low-traffic node. No
+      # traffic → no denominator series → no alert (correct).
       - alert: OSAHighHTTPErrorRate
         expr: |
           sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
           /
-          clamp_min(sum(rate(http_server_request_duration_seconds_count[5m])), 1) > 0.05
+          sum(rate(http_server_request_duration_seconds_count[5m])) > 0.05
         for: 10m
         labels:
           severity: warning

--- a/deploy/observability/alert-rules.yml
+++ b/deploy/observability/alert-rules.yml
@@ -111,12 +111,20 @@ groups:
       # smell that a stage checkpoint didn't survive and container work was
       # repeated. This is a heuristic — confirm with the workflow.stage spans
       # and the "Checkpoints" dashboard panel before treating it as real.
+      #
+      # The retry side uses rate() of the failed delivery-ATTEMPT counter
+      # (osa_deliveries_total{status="failed"}) — the one signal that genuinely
+      # rises while retries are in flight. This is the deliberate exception to
+      # the "don't read terminal failures from this counter" caveat: here we
+      # want attempts-in-progress, not terminal outcomes. It must NOT be
+      # osa_outbox_failed, which is a GAUGE of currently dead-lettered
+      # deliveries (rate() over it is meaningless and stays 0 once it settles).
       - alert: OSAWorkflowCheckpointLost
         expr: |
           (sum by (workflow, stage) (
             rate(osa_workflow_stages_total{outcome="ran", stage=~"hooks|insert_features|publish"}[15m])
           ) > 0)
-          and on() (sum(rate(osa_outbox_failed[15m])) > 0)
+          and on() (sum(rate(osa_deliveries_total{status="failed"}[15m])) > 0)
         for: 15m
         labels:
           severity: warning

--- a/deploy/observability/grafana-dashboard.json
+++ b/deploy/observability/grafana-dashboard.json
@@ -353,7 +353,7 @@
     {
       "type": "timeseries",
       "title": "HTTP 5xx ratio",
-      "description": "Fraction of requests returning 5xx.",
+      "description": "Fraction of requests returning 5xx. Natural ratio (no clamp_min): clamping a sub-1/s request rate would hide a 100%-5xx low-traffic node. No traffic renders no series.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -400,7 +400,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_request_duration_seconds_count[5m])), 1)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count[5m]))",
           "legendFormat": "5xx ratio",
           "range": true,
           "instant": false,

--- a/deploy/observability/grafana-dashboard.json
+++ b/deploy/observability/grafana-dashboard.json
@@ -1,0 +1,1375 @@
+{
+  "uid": "osa-observability",
+  "title": "OSA \u2014 Observability",
+  "description": "Node health, outbox/queue, workflow stages, hooks, ingest, and runtime resources for an OSA node. Metrics from GET /metrics (see docs/observability.md).",
+  "tags": [
+    "osa",
+    "observability"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Prometheus data source",
+        "current": {},
+        "hide": 0
+      },
+      {
+        "name": "hook",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "query": "label_values(osa_hook_runs_total, hook)",
+          "refId": "hook"
+        },
+        "definition": "label_values(osa_hook_runs_total, hook)",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "label": "Hook"
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations & Alerts",
+        "enable": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "type": "dashboard",
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Node health & API edge",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Workers busy / total",
+      "description": "Worker loops currently processing a batch vs. total in the pool.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_workers_busy",
+          "legendFormat": "busy",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_workers_total",
+          "legendFormat": "total",
+          "range": false,
+          "instant": true,
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Unhandled 5xx / s",
+      "description": "Exceptions reaching the global error handler (surfaced as 500s).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(osa_unhandled_errors_total[5m]))",
+          "legendFormat": "5xx/s",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP request rate by route",
+      "description": "From the auto-instrumented FastAPI histogram. Adjust the metric/label names to your OTel semconv version if needed.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count[5m]))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP latency p50 / p95 / p99",
+      "description": "Request latency percentiles across all routes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP 5xx ratio",
+      "description": "Fraction of requests returning 5xx.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_request_duration_seconds_count[5m])), 1)",
+          "legendFormat": "5xx ratio",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Outbox & queue health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Outbox lag (oldest eligible delivery)",
+      "description": "Age of the oldest claimable pending delivery. 0 when the queue is empty.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_outbox_lag_seconds",
+          "legendFormat": "lag",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Pending deliveries by consumer group",
+      "description": "Unclaimed deliveries per consumer group (ProcessSubmission, ProcessBatch).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_outbox_pending",
+          "legendFormat": "{{consumer_group}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Failed (dead-lettered) deliveries by group",
+      "description": "Deliveries that exhausted their retry budget. These need operator attention.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_outbox_failed",
+          "legendFormat": "{{consumer_group}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Dispatch duration p95 by group",
+      "description": "Since #160 one dispatch times a WHOLE workflow (can span minutes-hours for ProcessBatch). For per-stage latency read the workflow.stage spans, not this.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, consumer_group) (rate(osa_dispatch_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{consumer_group}} p95",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Delivery attempt outcomes by group",
+      "description": "Dispatch-ATTEMPT outcomes. status=failed counts attempts, not terminal failures (one retry budget spans the workflow) \u2014 read terminal outcomes from the ingest counters below.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (consumer_group, status) (rate(osa_deliveries_total[5m]))",
+          "legendFormat": "{{consumer_group}} {{status}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Workflow stages",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Stage executions by workflow / stage / outcome",
+      "description": "ran = did the work; skipped = redelivery fast-forwarded past a cleared checkpoint; failed = retried.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (workflow, stage, outcome) (rate(osa_workflow_stages_total[5m]))",
+          "legendFormat": "{{workflow}}/{{stage}} {{outcome}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Checkpoint-loss signal (expensive stage re-runs)",
+      "description": "Heuristic. Expensive stages re-running (ran) while deliveries retry can mean a lost checkpoint repeated container work. Confirm with the workflow.stage spans.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.001
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(osa_workflow_stages_total{outcome=\"ran\", stage=~\"hooks|insert_features|publish\"}[15m]))",
+          "legendFormat": "ran/s",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Hook execution",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Hook runs by status",
+      "description": "Completed hook executions by terminal status (passed/warnings/failed/error).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status) (rate(osa_hook_runs_total[5m]))",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Hook duration p95 by hook",
+      "description": "Wall-clock p95 per hook.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, hook) (rate(osa_hook_run_duration_seconds_bucket{hook=~\"$hook\"}[5m])))",
+          "legendFormat": "{{hook}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Hook failures by kind / decision",
+      "description": "Failures by observed cause and the policy decision taken, plus OOM memory-bump retries.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (kind, decision) (rate(osa_hook_failures_total[10m]))",
+          "legendFormat": "{{kind}} \u2192 {{decision}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(osa_hook_oom_retries_total[10m]))",
+          "legendFormat": "oom retries",
+          "range": true,
+          "instant": false,
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Ingest throughput",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Records published / s",
+      "description": "Records published by completed ingest batches.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(osa_records_published_total[5m]))",
+          "legendFormat": "records/s",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingest batches by outcome",
+      "description": "Batches reaching a terminal state; kind is the failure cause on failed batches.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (outcome, kind) (rate(osa_ingest_batches_total[10m]))",
+          "legendFormat": "{{outcome}} ({{kind}})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingest runs by status (terminal)",
+      "description": "Runs reaching a terminal status \u2014 the trustworthy terminal-failure signal.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status, kind) (rate(osa_ingest_runs_total[15m]))",
+          "legendFormat": "{{status}} ({{kind}})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Runtime resources",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "DB connection pool",
+      "description": "SQLAlchemy pool occupancy. checked_out approaching size (then spilling into overflow) signals saturation.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_db_pool_checked_out",
+          "legendFormat": "checked out",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_db_pool_size",
+          "legendFormat": "size",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_db_pool_overflow",
+          "legendFormat": "overflow",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool utilisation",
+      "description": "checked_out / size. >0.9 sustained is the DBPoolSaturated alert condition.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "osa_db_pool_checked_out / clamp_min(osa_db_pool_size, 1)",
+          "legendFormat": "utilisation",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -321,6 +321,26 @@ without blocking delivery. Sampling is head-based via
 `OSA_OBSERVABILITY__TRACE_SAMPLE_RATE` — the decision is made once at the root
 and honored consistently down the chain.
 
+## Prebuilt dashboard & alert rules
+
+Importable monitoring config lives in
+[`deploy/observability/`](../deploy/observability/):
+
+- **`grafana-dashboard.json`** — a Grafana dashboard covering node health, the
+  outbox/queue, workflow stages, hooks, ingest throughput, and runtime
+  resources. Import it and pick your Prometheus data source (the dashboard uses
+  a `$datasource` variable; no UID is hardcoded).
+- **`alert-rules.yml`** — example Prometheus alerting rules (telemetry
+  staleness, outbox backlog, dead-lettered deliveries, terminal ingest
+  failures, hook infra failures, DB pool saturation, and a heuristic
+  checkpoint-loss detector). Thresholds are starting points — tune to your SLOs.
+
+Both encode the two #160 reading caveats (dispatch duration times a whole
+workflow; `osa_deliveries_total{status="failed"}` counts attempts, not terminal
+failures) so you don't have to rediscover them. This ships importable config,
+not a running Prometheus/Grafana stack. See
+[`deploy/observability/README.md`](../deploy/observability/README.md).
+
 ## Security notes
 
 - **`/metrics` is unauthenticated.** The Prometheus endpoint has no auth gate by


### PR DESCRIPTION
Ships the Phase 4.1 "polish" artifacts from #158: importable monitoring config that consumes the metrics an OSA node already exposes. **No server-side behavior changes** — this is config + data + one CI job.

Phases 1–3 of #158 (the OTel pipeline, metrics, traces, health/readiness) landed in #159; this closes the remaining consumer-side convenience so self-hosters get a useful view out of the box instead of raw `osa_*` series.

## What's here

- **`deploy/observability/grafana-dashboard.json`** — dashboard with rows for node health & API edge, outbox & queue, workflow stages, hook execution, ingest throughput, and runtime resources. Parameterized on a `$datasource` variable (no hardcoded Prometheus UID) with a `$hook` filter for the per-hook panels.
- **`deploy/observability/alert-rules.yml`** — example Prometheus rules across six groups: push-model telemetry staleness, outbox backlog/dead-lettering, terminal ingest failures, operator-fixable hook infra failures, unhandled 5xx, DB pool saturation, and a heuristic checkpoint-loss detector.
- **`deploy/observability/README.md`** — import instructions and the reading caveats.
- **CI** — new `observability-config` job validates the dashboard JSON and runs `promtool check rules`; `paths-filter` gates it on `deploy/observability/**`.
- **`docs/observability.md`** — links the new config.

## The actual value: #160-aware semantics

The panels are easy; encoding the traps is the point:

- Alerts read terminal outcomes from the **domain** counters (`osa_ingest_runs_total{status="failed"}`, `osa_ingest_batches_total{outcome="failed"}`), **not** `osa_deliveries_total{status="failed"}` — since #160 one retry budget spans a whole workflow and redeliveries fast-forward past cleared stages, so failed *attempts* inflate and aren't terminal failures.
- `osa_dispatch_duration_seconds` is treated as a whole-workflow timer (can span minutes–hours for `ProcessBatch`), not per-hop latency — per-stage latency is the `workflow.stage` spans.

## Verification

- `promtool check rules deploy/observability/alert-rules.yml` → `SUCCESS: 12 rules found`
- Dashboard JSON parses (26 panels); `$datasource`/`$hook` templating, no hardcoded data-source UID
- Both checks run in CI on any change under `deploy/observability/**`

## Out of scope (per #158)

- Bundling Prometheus/Grafana **services** into `deploy/docker-compose.yml` — this ships importable config, not a running stack.
- Public OTLP gateway opt-in for self-hosted nodes — cloud-side (`opensciencearchive/cloud#40`).

Closes #166.
