### PR TITLE
feat: make the /data read surface honest and complete for agents

### DIFF
--- a/server/osa/application/api/v1/routes/data/_params.py
+++ b/server/osa/application/api/v1/routes/data/_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from osa.domain.data.model.filter import FilterExpr
 from osa.domain.data.model.query_plan import SortDirection, SortSpec
@@ -10,7 +10,14 @@ from osa.domain.shared.error import ValidationError
 
 
 class FilterRequestBody(BaseModel):
-    """POST body shared by every table format (records + feature)."""
+    """POST body shared by every table format (records + feature).
+
+    ``extra="forbid"``: a mis-shaped body (e.g. an agent copying a wrong filter
+    DSL) must 422 at the edge rather than be silently dropped and the read run
+    unfiltered — a wrong-but-plausible 200 is the worst outcome for an agent.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     filter: FilterExpr | None = None
     cursor: str | None = None

--- a/server/osa/application/api/v1/routes/data/_streaming.py
+++ b/server/osa/application/api/v1/routes/data/_streaming.py
@@ -79,6 +79,8 @@ async def _paginated_response(
 
     serializer = fmt.make_serializer()
     return StreamingResponse(
-        serializer.stream(page_iter(), columns, next_cursor=slice_.next_cursor),
+        serializer.stream(
+            page_iter(), columns, next_cursor=slice_.next_cursor, has_more=slice_.truncated
+        ),
         media_type=fmt.media_type,
     )

--- a/server/osa/application/api/v1/routes/data/serializers/csv.py
+++ b/server/osa/application/api/v1/routes/data/serializers/csv.py
@@ -44,7 +44,9 @@ class CsvSerializer:
         columns: Sequence[ColumnSpec],
         *,
         next_cursor: str | None = None,
+        has_more: bool = False,
     ) -> AsyncIterator[bytes]:
+        # Streaming formats ignore paging state (next_cursor/has_more).
         names = [col.name for col in columns]
         encoder = _RowEncoder()
 

--- a/server/osa/application/api/v1/routes/data/serializers/csv_gzip.py
+++ b/server/osa/application/api/v1/routes/data/serializers/csv_gzip.py
@@ -30,7 +30,9 @@ class CsvGzipSerializer:
         columns: Sequence[ColumnSpec],
         *,
         next_cursor: str | None = None,
+        has_more: bool = False,
     ) -> AsyncIterator[bytes]:
+        # Streaming formats ignore paging state (next_cursor/has_more).
         compressor = zlib.compressobj(level=6, wbits=zlib.MAX_WBITS | 16)
         async for chunk in self._csv.stream(rows, columns):
             compressed = compressor.compress(chunk)

--- a/server/osa/application/api/v1/routes/data/serializers/json.py
+++ b/server/osa/application/api/v1/routes/data/serializers/json.py
@@ -1,8 +1,11 @@
-"""JSON serializer — paginated envelope ``{"rows": [...], "next_cursor": ...}``.
+"""JSON serializer — paginated envelope
+``{"rows": [...], "next_cursor": ..., "has_more": ...}``.
 
 Built row-by-row so the whole page is never held twice in memory. The
-``next_cursor`` is precomputed by the query service and passed in; an empty
-result yields ``{"rows": [], "next_cursor": null}`` with HTTP 200.
+``next_cursor`` and ``has_more`` are precomputed by the query service and passed
+in; an empty result yields ``{"rows": [], "next_cursor": null, "has_more": false}``
+with HTTP 200. ``has_more`` lets a consumer distinguish a *complete* page from a
+*truncated* one without inspecting the cursor.
 """
 
 from __future__ import annotations
@@ -23,6 +26,7 @@ class JsonSerializer:
         columns: Sequence[ColumnSpec],
         *,
         next_cursor: str | None = None,
+        has_more: bool = False,
     ) -> AsyncIterator[bytes]:
         yield b'{"rows":['
         first = True
@@ -35,4 +39,5 @@ class JsonSerializer:
                 chunk = b"," + chunk
             yield chunk
         cursor_json = json.dumps(next_cursor).encode()
-        yield b'],"next_cursor":' + cursor_json + b"}"
+        has_more_json = b"true" if has_more else b"false"
+        yield b'],"next_cursor":' + cursor_json + b',"has_more":' + has_more_json + b"}"

--- a/server/osa/application/api/v1/routes/data/serializers/protocol.py
+++ b/server/osa/application/api/v1/routes/data/serializers/protocol.py
@@ -5,10 +5,11 @@ Serializers are stateless and have no I/O dependencies beyond stdlib (``json``,
 (column→value mappings) and the column schema that fixes wire order, and yield
 response bytes incrementally so streaming formats stay memory-bounded.
 
-Note on ``next_cursor``: cursor derivation lives in the query service (matching
-the proven discovery engine), not in the serializer. Paginated serializers
-(JSON) receive the precomputed ``next_cursor`` to embed in the envelope;
-streaming serializers (CSV, CSV.gz) ignore it.
+Note on ``next_cursor``/``has_more``: paging state is derived in the query
+service (matching the proven discovery engine), not in the serializer.
+Paginated serializers (JSON) receive the precomputed ``next_cursor`` and
+``has_more`` to embed in the envelope; streaming serializers (CSV, CSV.gz)
+ignore them.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ class Serializer(Protocol):
         columns: Sequence[ColumnSpec],
         *,
         next_cursor: str | None = None,
+        has_more: bool = False,
     ) -> AsyncIterator[bytes]:
         """Render ``rows`` as response bytes, yielded incrementally."""
         ...

--- a/server/osa/domain/data/model/manifest.py
+++ b/server/osa/domain/data/model/manifest.py
@@ -67,6 +67,11 @@ class TableResource(BaseModel):
     kind: TableKind
     columns: list[ColumnSpec]
     row_count: int
+    # Distinct records this feature table covers (COUNT(DISTINCT record_srn)).
+    # Feature-only: lets a consumer tell "empty because that's all there is" from
+    # "1 row that happens to cover 1/N records". None (omitted) on the records
+    # resource, where coverage is not a meaningful concept.
+    records_covered: int | None = None
     formats: list[str]  # URL suffixes, e.g. ["", "csv", "csv.gz"]
 
 

--- a/server/osa/domain/data/model/skill.py
+++ b/server/osa/domain/data/model/skill.py
@@ -67,6 +67,19 @@ class SampleValue(BaseModel):
     value: str | int | float | bool
 
 
+class FeatureCoverage(BaseModel):
+    """Per-feature-table coverage for one dataset (SKILL.md).
+
+    ``records_covered`` is how many of the dataset's ``row_count`` records have
+    ≥1 row in this feature table — the signal that turns a deceptive 1-row
+    table into an obvious coverage gap.
+    """
+
+    name: str
+    row_count: int
+    records_covered: int
+
+
 class DatasetEntry(BaseModel):
     """One row of the SKILL.md datasets table.
 
@@ -78,3 +91,4 @@ class DatasetEntry(BaseModel):
     schema_ref: str  # "<id>@<version>"
     title: str
     row_count: int
+    features: list[FeatureCoverage] = []

--- a/server/osa/domain/data/service/skill_generator.py
+++ b/server/osa/domain/data/service/skill_generator.py
@@ -98,10 +98,16 @@ class SkillGeneratorService(Service):
         sample: SampleValue | None = None
         if sample_field is not None:
             sample = await self.read_store.sample_value(schema_id, "records", sample_field)
+        feature_target = self.renderer.feature_example_target(manifest)
+        feature_sample: SampleValue | None = None
+        if feature_target is not None:
+            feat_table, feat_col = feature_target
+            feature_sample = await self.read_store.sample_value(schema_id, feat_table, feat_col)
         return self.renderer.render_reference(
             manifest=manifest,
             docs=docs,
             base_url=self._base_url(),
             sample_field=sample_field,
             sample=sample,
+            feature_sample=feature_sample,
         )

--- a/server/osa/domain/data/service/skill_generator.py
+++ b/server/osa/domain/data/service/skill_generator.py
@@ -8,8 +8,10 @@ pure :class:`SkillRenderer`. All I/O goes through the data read-store port.
 from __future__ import annotations
 
 from osa.config import Config
+from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import (
     DatasetEntry,
+    FeatureCoverage,
     NodeIdentity,
     RootDiscovery,
     SampleValue,
@@ -65,6 +67,15 @@ class SkillGeneratorService(Service):
                     schema_ref=f"{entry.id}@{entry.version}",
                     title=manifest.title,
                     row_count=records.row_count,
+                    features=[
+                        FeatureCoverage(
+                            name=t.name,
+                            row_count=t.row_count,
+                            records_covered=t.records_covered or 0,
+                        )
+                        for t in manifest.table_resources
+                        if t.kind == TableKind.FEATURE
+                    ],
                 )
             )
             author_docs = await self.read_store.get_author_docs(schema_id)

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -19,6 +19,7 @@ from osa.domain.data.model.manifest import (
 )
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, NodeIdentity, SampleValue
+from osa.domain.semantics.model.value import FieldType
 from osa.domain.shared.service import Service
 
 # A clearly-labeled stand-in used when no real value could be sampled
@@ -28,6 +29,19 @@ PLACEHOLDER_VALUE = "REPLACE_WITH_A_REAL_VALUE"
 # Auto columns on every feature table — excluded when picking a data column to
 # template a feature-filter example on.
 _IMPLICIT_FEATURE_NAMES = {c.name for c in IMPLICIT_FEATURE_COLUMN_SPECS}
+
+
+def _example_value_for(field_type: FieldType) -> str | int | bool:
+    """A type-valid stand-in for the filter example when no real value could be
+    sampled. A numeric or boolean column needs a *castable* literal — the string
+    placeholder would make the advertised POST uncastable and 500 in PostgreSQL.
+    Text-like columns keep the clearly-labelled 'replace me' string."""
+    if field_type == FieldType.NUMBER:
+        return 0
+    if field_type == FieldType.BOOLEAN:
+        return False
+    return PLACEHOLDER_VALUE
+
 
 # Fixed documentation for the implicit records-table columns (wire order).
 _IMPLICIT_RECORD_DOCS: list[tuple[str, str, str]] = [
@@ -331,7 +345,10 @@ class SkillRenderer(Service):
         lines.append(f"   GET {data_base}/{schema_ref}/records.csv.gz")
         if sample_field is not None:
             n += 1
-            value = sample.value if sample is not None else PLACEHOLDER_VALUE
+            field_type = next(
+                (f.type for f in manifest.fields if f.name == sample_field), FieldType.TEXT
+            )
+            value = sample.value if sample is not None else _example_value_for(field_type)
             body = json.dumps(
                 {
                     "filter": {
@@ -361,12 +378,17 @@ class SkillRenderer(Service):
             data_cols = [c for c in feature.columns if c.name not in _IMPLICIT_FEATURE_NAMES]
             if data_cols:
                 n += 1
-                col = data_cols[0].name
+                col_spec = data_cols[0]
+                col = col_spec.name
                 # Use a real sampled value (typed, castable) when the table has
-                # data, mirroring the metadata example; the string placeholder is
-                # only for an empty column. A raw placeholder against a numeric or
-                # boolean column would be an uncastable value → server error.
-                fvalue = feature_sample.value if feature_sample is not None else PLACEHOLDER_VALUE
+                # data, mirroring the metadata example; otherwise a type-valid
+                # placeholder — a raw string against a numeric or boolean column
+                # would be an uncastable value → server error on the runnable POST.
+                fvalue = (
+                    feature_sample.value
+                    if feature_sample is not None
+                    else _example_value_for(col_spec.type)
+                )
                 fbody = json.dumps(
                     {
                         "filter": {

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -12,7 +12,11 @@ import json
 import re
 from urllib.parse import quote
 
-from osa.domain.data.model.manifest import SchemaManifest, TableResource
+from osa.domain.data.model.manifest import (
+    IMPLICIT_FEATURE_COLUMN_SPECS,
+    SchemaManifest,
+    TableResource,
+)
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, NodeIdentity, SampleValue
 from osa.domain.shared.service import Service
@@ -20,6 +24,10 @@ from osa.domain.shared.service import Service
 # A clearly-labeled stand-in used when no real value could be sampled
 # (empty column/table — FR-021/022); the example stays syntactically valid.
 PLACEHOLDER_VALUE = "REPLACE_WITH_A_REAL_VALUE"
+
+# Auto columns on every feature table — excluded when picking a data column to
+# template a feature-filter example on.
+_IMPLICIT_FEATURE_NAMES = {c.name for c in IMPLICIT_FEATURE_COLUMN_SPECS}
 
 # Fixed documentation for the implicit records-table columns (wire order).
 _IMPLICIT_RECORD_DOCS: list[tuple[str, str, str]] = [
@@ -92,8 +100,28 @@ class SkillRenderer(Service):
         else:
             lines.append("No datasets yet.")
 
+        coverage = [(ds, fc) for ds in datasets for fc in ds.features]
+        if coverage:
+            lines.append("")
+            lines.append("Feature-table coverage (rows · records covered):")
+            lines.append("")
+            for ds, fc in coverage:
+                lines.append(
+                    f"- {ds.schema_ref} · {fc.name}: {fc.row_count} rows, "
+                    f"{fc.records_covered}/{ds.row_count} records covered"
+                )
+
         lines.append("")
         lines.append("## Access")
+        lines.append("")
+        # Start here: records hold identifiers + metadata; the science is in the
+        # feature tables, joined back on record_srn. Say so before the endpoints,
+        # so an agent doesn't download the id-only records dump expecting data.
+        lines.append(
+            "Records tables carry identifiers and metadata; the measured and derived "
+            "science lives in each schema's feature tables (listed in its Reference doc). "
+            "Join feature rows to records on `record_srn` = `records.srn`."
+        )
         lines.append("")
         lines.append(f"- Bulk:   GET  {base_url}/api/v1/data/<schema>/records.csv.gz")
         lines.append(
@@ -166,10 +194,14 @@ class SkillRenderer(Service):
         lines.extend(self._records_table_section(manifest))
 
         if features:
+            records = next(
+                (t for t in manifest.table_resources if t.kind == TableKind.RECORDS), None
+            )
+            records_total = records.row_count if records is not None else 0
             lines.append("")
             lines.append("## Feature tables")
             for feature in features:
-                lines.extend(self._feature_section(feature))
+                lines.extend(self._feature_section(feature, records_total))
 
         lines.extend(self._join_provenance_section(base_url, features))
         lines.extend(
@@ -220,14 +252,28 @@ class SkillRenderer(Service):
         return lines
 
     @staticmethod
-    def _feature_section(feature: TableResource) -> list[str]:
+    def _feature_section(feature: TableResource, records_total: int) -> list[str]:
         lines = ["", f"### {feature.name}", ""]
-        lines.append("| Column | Type | Format | Unit | Description |")
-        lines.append("|---|---|---|---|---|")
+        if feature.records_covered is not None:
+            pct = (
+                f" ({round(100 * feature.records_covered / records_total)}%)"
+                if records_total
+                else ""
+            )
+            lines.append(
+                f"{feature.row_count} rows · covers {feature.records_covered} of "
+                f"{records_total} records{pct}."
+            )
+            lines.append("")
+        # The Filter ref column is the one datum needed to filter a column, sat
+        # right next to the column: features.<hook>.<column> (the hook == the
+        # feature-table name). Usable today on this feature's own table stream.
+        lines.append("| Column | Type | Format | Unit | Description | Filter ref |")
+        lines.append("|---|---|---|---|---|---|")
         for c in feature.columns:
             lines.append(
                 f"| {c.name} | {c.type.value} | {c.format or ''} | {c.unit or ''} "
-                f"| {c.description or ''} |"
+                f"| {c.description or ''} | features.{feature.name}.{c.name} |"
             )
         return lines
 
@@ -296,6 +342,26 @@ class SkillRenderer(Service):
             )
             lines.append("")
             lines.append(f"   GET {data_base}/{schema_ref}/{feature.name}.csv.gz")
+            data_cols = [c for c in feature.columns if c.name not in _IMPLICIT_FEATURE_NAMES]
+            if data_cols:
+                n += 1
+                col = data_cols[0].name
+                fbody = json.dumps(
+                    {
+                        "filter": {
+                            "kind": "predicate",
+                            "field": f"features.{feature.name}.{col}",
+                            "op": "eq",
+                            "value": PLACEHOLDER_VALUE,
+                        }
+                    },
+                    ensure_ascii=False,
+                )
+                lines.append("")
+                lines.append(f"{n}. Filter a feature table by one of its columns:")
+                lines.append("")
+                lines.append(f"   POST {data_base}/{schema_ref}/{feature.name}")
+                lines.append(f"   {fbody}")
         n += 1
         lines.append("")
         lines.append(f"{n}. Single record:")

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -169,6 +169,19 @@ class SkillRenderer(Service):
         metadata field (research §9). ``None`` when the schema has no fields."""
         return manifest.fields[0].name if manifest.fields else None
 
+    @staticmethod
+    def feature_example_target(manifest: SchemaManifest) -> tuple[str, str] | None:
+        """``(feature_table, column)`` the feature-filter example templates on —
+        the first data column of the first feature table. The single owner of
+        that choice, so the generator samples the same column the renderer emits.
+        ``None`` when no feature table has a data column."""
+        for t in manifest.table_resources:
+            if t.kind == TableKind.FEATURE:
+                data_cols = [c for c in t.columns if c.name not in _IMPLICIT_FEATURE_NAMES]
+                if data_cols:
+                    return t.name, data_cols[0].name
+        return None
+
     def render_reference(
         self,
         *,
@@ -177,6 +190,7 @@ class SkillRenderer(Service):
         base_url: str,
         sample_field: str | None,
         sample: SampleValue | None,
+        feature_sample: SampleValue | None = None,
     ) -> str:
         schema_ref = f"{manifest.id}@{manifest.version}"
         features = [t for t in manifest.table_resources if t.kind == TableKind.FEATURE]
@@ -211,6 +225,7 @@ class SkillRenderer(Service):
                 features=features,
                 sample_field=sample_field,
                 sample=sample,
+                feature_sample=feature_sample,
             )
         )
 
@@ -302,6 +317,7 @@ class SkillRenderer(Service):
         features: list[TableResource],
         sample_field: str | None,
         sample: SampleValue | None,
+        feature_sample: SampleValue | None = None,
     ) -> list[str]:
         data_base = f"{base_url}/api/v1/data"
         # Fully-qualified <id>@<version>: the doc may have been requested at a
@@ -346,13 +362,18 @@ class SkillRenderer(Service):
             if data_cols:
                 n += 1
                 col = data_cols[0].name
+                # Use a real sampled value (typed, castable) when the table has
+                # data, mirroring the metadata example; the string placeholder is
+                # only for an empty column. A raw placeholder against a numeric or
+                # boolean column would be an uncastable value → server error.
+                fvalue = feature_sample.value if feature_sample is not None else PLACEHOLDER_VALUE
                 fbody = json.dumps(
                     {
                         "filter": {
                             "kind": "predicate",
                             "field": f"features.{feature.name}.{col}",
                             "op": "eq",
-                            "value": PLACEHOLDER_VALUE,
+                            "value": fvalue,
                         }
                     },
                     ensure_ascii=False,

--- a/server/osa/domain/data/service/skill_renderer.py
+++ b/server/osa/domain/data/service/skill_renderer.py
@@ -19,28 +19,36 @@ from osa.domain.data.model.manifest import (
 )
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, NodeIdentity, SampleValue
-from osa.domain.semantics.model.value import FieldType
 from osa.domain.shared.service import Service
-
-# A clearly-labeled stand-in used when no real value could be sampled
-# (empty column/table — FR-021/022); the example stays syntactically valid.
-PLACEHOLDER_VALUE = "REPLACE_WITH_A_REAL_VALUE"
 
 # Auto columns on every feature table — excluded when picking a data column to
 # template a feature-filter example on.
 _IMPLICIT_FEATURE_NAMES = {c.name for c in IMPLICIT_FEATURE_COLUMN_SPECS}
 
+# Swapped for a ``<column>`` token when no real value could be sampled — see
+# ``_filter_example``.
+_TEMPLATE_SENTINEL = "__OSA_TEMPLATE_VALUE__"
 
-def _example_value_for(field_type: FieldType) -> str | int | bool:
-    """A type-valid stand-in for the filter example when no real value could be
-    sampled. A numeric or boolean column needs a *castable* literal — the string
-    placeholder would make the advertised POST uncastable and 500 in PostgreSQL.
-    Text-like columns keep the clearly-labelled 'replace me' string."""
-    if field_type == FieldType.NUMBER:
-        return 0
-    if field_type == FieldType.BOOLEAN:
-        return False
-    return PLACEHOLDER_VALUE
+
+def _filter_example(field_ref: str, sample: SampleValue | None, token: str) -> tuple[str, bool]:
+    """The POST body for an ``eq`` filter example, and whether it is runnable.
+
+    With a sampled value the body is concrete, valid JSON, copy-runnable. Without
+    one (empty column) there is no real value to demonstrate, so the value is a
+    ``<token>`` placeholder — deliberately *not* valid JSON, so the example reads
+    as a fill-in template and can never be mistaken for a runnable request. A
+    fabricated literal would be worse: for a numeric/date/boolean column a
+    stand-in string is uncastable (500), and any made-up value is a meaningless
+    filter presented as real."""
+    runnable = sample is not None
+    value = sample.value if sample is not None else _TEMPLATE_SENTINEL
+    body = json.dumps(
+        {"filter": {"kind": "predicate", "field": field_ref, "op": "eq", "value": value}},
+        ensure_ascii=False,
+    )
+    if not runnable:
+        body = body.replace(f'"{_TEMPLATE_SENTINEL}"', f"<{token}>")
+    return body, runnable
 
 
 # Fixed documentation for the implicit records-table columns (wire order).
@@ -345,23 +353,14 @@ class SkillRenderer(Service):
         lines.append(f"   GET {data_base}/{schema_ref}/records.csv.gz")
         if sample_field is not None:
             n += 1
-            field_type = next(
-                (f.type for f in manifest.fields if f.name == sample_field), FieldType.TEXT
-            )
-            value = sample.value if sample is not None else _example_value_for(field_type)
-            body = json.dumps(
-                {
-                    "filter": {
-                        "kind": "predicate",
-                        "field": f"metadata.{sample_field}",
-                        "op": "eq",
-                        "value": value,
-                    }
-                },
-                ensure_ascii=False,
+            body, runnable = _filter_example(f"metadata.{sample_field}", sample, sample_field)
+            hint = (
+                "use for large tables"
+                if runnable
+                else f"replace <{sample_field}> with a real value"
             )
             lines.append("")
-            lines.append(f"{n}. Filtered query (FilterExpr POST — use for large tables):")
+            lines.append(f"{n}. Filtered query (FilterExpr POST — {hint}):")
             lines.append("")
             lines.append(f"   POST {data_base}/{schema_ref}/records")
             lines.append(f"   {body}")
@@ -378,30 +377,13 @@ class SkillRenderer(Service):
             data_cols = [c for c in feature.columns if c.name not in _IMPLICIT_FEATURE_NAMES]
             if data_cols:
                 n += 1
-                col_spec = data_cols[0]
-                col = col_spec.name
-                # Use a real sampled value (typed, castable) when the table has
-                # data, mirroring the metadata example; otherwise a type-valid
-                # placeholder — a raw string against a numeric or boolean column
-                # would be an uncastable value → server error on the runnable POST.
-                fvalue = (
-                    feature_sample.value
-                    if feature_sample is not None
-                    else _example_value_for(col_spec.type)
+                col = data_cols[0].name
+                fbody, frunnable = _filter_example(
+                    f"features.{feature.name}.{col}", feature_sample, col
                 )
-                fbody = json.dumps(
-                    {
-                        "filter": {
-                            "kind": "predicate",
-                            "field": f"features.{feature.name}.{col}",
-                            "op": "eq",
-                            "value": fvalue,
-                        }
-                    },
-                    ensure_ascii=False,
-                )
+                suffix = "" if frunnable else f" (replace <{col}> with a real value)"
                 lines.append("")
-                lines.append(f"{n}. Filter a feature table by one of its columns:")
+                lines.append(f"{n}. Filter a feature table by one of its columns{suffix}:")
                 lines.append("")
                 lines.append(f"   POST {data_base}/{schema_ref}/{feature.name}")
                 lines.append(f"   {fbody}")

--- a/server/osa/infrastructure/data/postgres_catalog_read_store.py
+++ b/server/osa/infrastructure/data/postgres_catalog_read_store.py
@@ -206,6 +206,7 @@ class PostgresCatalogReadStore:
         for hook_name, fschema in await self._features.feature_tables(schema_id):
             ft = build_feature_table(hook_name, fschema)
             count = await self._features.count_rows(ft, schema_id)
+            covered = await self._features.count_covered_records(ft, schema_id)
             resources.append(
                 TableResource(
                     name=hook_name,
@@ -214,6 +215,7 @@ class PostgresCatalogReadStore:
                     # hook's declared data columns — this is the CSV header order.
                     columns=[*IMPLICIT_FEATURE_COLUMN_SPECS, *self._feature_column_specs(fschema)],
                     row_count=count,
+                    records_covered=covered,
                     formats=list(_ALL_FORMATS),
                 )
             )

--- a/server/osa/infrastructure/data/schema_feature_reader.py
+++ b/server/osa/infrastructure/data/schema_feature_reader.py
@@ -51,6 +51,20 @@ class SchemaFeatureReader:
         )
         return int((await self.session.execute(stmt)).scalar_one())
 
+    async def count_covered_records(self, ft: sa.Table, schema_id: SchemaId) -> int:
+        """Distinct records with ≥1 row in this feature table (join coverage).
+
+        Feature tables are 1-to-many with records, so ``count_rows`` alone can't
+        tell a 1-row table that covers 1 record from one that covers many; this
+        is ``COUNT(DISTINCT record_srn)`` over the same schema-scoped join.
+        """
+        stmt = (
+            select(func.count(func.distinct(ft.c.record_srn)))
+            .select_from(ft.join(records_table, records_table.c.srn == ft.c.record_srn))
+            .where(and_(*self.records_scope(schema_id)))
+        )
+        return int((await self.session.execute(stmt)).scalar_one())
+
     @staticmethod
     def records_scope(schema_id: SchemaId) -> list[Any]:
         """Records-join conditions scoping a shared feature table to one schema."""

--- a/server/tests/contract/test_data_surface_contract.py
+++ b/server/tests/contract/test_data_surface_contract.py
@@ -49,6 +49,23 @@ async def test_legacy_read_routes_are_gone(client: AsyncClient, path: str):
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/api/v1/data/some-schema@1.0.0/records"])
+async def test_post_filter_body_rejects_unknown_keys(client: AsyncClient, path: str):
+    """A mis-shaped filter body must 422 at the edge, never run unfiltered (BUG-1).
+
+    The documented DSL an agent might copy (``{"feature":…,"where":{"eq":…}}``) is
+    not the wire format; today it is silently dropped and the read runs unfiltered,
+    returning a plausible first page. Body validation must reject unknown top-level
+    keys before the handler (and the DB) are ever reached — so this is DB-free.
+    """
+    async with client:
+        resp = await client.post(
+            path, json={"feature": "x", "where": {"eq": {"optimum": "tolerant"}}}
+        )
+    assert resp.status_code == 422
+
+
 def test_data_surface_operation_ids_registered():
     # The factory-minted table op IDs must exist and be unique (SDK codegen).
     app = _app()

--- a/server/tests/integration/test_data_features_postgres.py
+++ b/server/tests/integration/test_data_features_postgres.py
@@ -334,6 +334,36 @@ class TestFeatureCatalogAndManifest:
         assert "score" in col_names and "label" in col_names
         assert feature_res.formats == ["", "csv", "csv.gz"]
 
+    async def test_manifest_records_covered_counts_distinct_records(
+        self, pg_engine: AsyncEngine, pg_session: AsyncSession
+    ):
+        # AX-3: two records, but only one carries feature rows — and it carries
+        # TWO. row_count counts feature rows (2); records_covered counts distinct
+        # records (1). This is the pilot's deceptive 1-of-148 case, made visible.
+        store = await _setup_schema(pg_engine, pg_session)
+        srn1 = await _publish(pg_engine, store, "rec1")
+        await _publish(pg_engine, store, "rec2")
+        await pg_session.commit()
+        run_id = await _register_hook(pg_engine, pg_session)
+        feature_store = PostgresFeatureStore(pg_engine, pg_session)
+        await feature_store.insert_features(
+            HOOK,
+            str(srn1),
+            [{"score": 0.9, "label": "a"}, {"score": 0.1, "label": "b"}],
+            run_id,
+        )
+
+        rs = PostgresCatalogReadStore(pg_session, Domain("localhost"))
+        manifest = await rs.get_schema_manifest(SCHEMA)
+        assert manifest is not None
+        feature_res = next(t for t in manifest.table_resources if t.name == HOOK)
+        assert feature_res.row_count == 2
+        assert feature_res.records_covered == 1
+        # Coverage is not a meaningful concept for the records resource itself.
+        records_res = next(t for t in manifest.table_resources if t.name == "records")
+        assert records_res.row_count == 2
+        assert records_res.records_covered is None
+
     async def test_catalog_lists_feature_resource(
         self, pg_engine: AsyncEngine, pg_session: AsyncSession
     ):

--- a/server/tests/unit/application/api/v1/routes/data/serializers/test_json.py
+++ b/server/tests/unit/application/api/v1/routes/data/serializers/test_json.py
@@ -31,9 +31,12 @@ async def _collect(gen: AsyncIterator[bytes]) -> bytes:
 @pytest.mark.asyncio
 async def test_json_envelope_with_rows_and_cursor() -> None:
     rows = [{"id": "a", "mw": 1.5}, {"id": "b", "mw": 2.0}]
-    body = await _collect(JsonSerializer().stream(_aiter(rows), COLUMNS, next_cursor="CURSOR"))
+    body = await _collect(
+        JsonSerializer().stream(_aiter(rows), COLUMNS, next_cursor="CURSOR", has_more=True)
+    )
     parsed = json.loads(body)
     assert parsed["next_cursor"] == "CURSOR"
+    assert parsed["has_more"] is True
     assert parsed["rows"] == [{"id": "a", "mw": 1.5}, {"id": "b", "mw": 2.0}]
 
 
@@ -41,7 +44,16 @@ async def test_json_envelope_with_rows_and_cursor() -> None:
 async def test_json_empty_result_is_valid() -> None:
     body = await _collect(JsonSerializer().stream(_aiter([]), COLUMNS, next_cursor=None))
     parsed = json.loads(body)
-    assert parsed == {"rows": [], "next_cursor": None}
+    assert parsed == {"rows": [], "next_cursor": None, "has_more": False}
+
+
+@pytest.mark.asyncio
+async def test_json_has_more_flag_defaults_false() -> None:
+    # has_more lets an agent tell a complete page from a truncated one — the
+    # ambiguity that sent the pilot session on a long detour. Default: no more.
+    body = await _collect(JsonSerializer().stream(_aiter([{"id": "a", "mw": 1.5}]), COLUMNS))
+    parsed = json.loads(body)
+    assert parsed["has_more"] is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/application/api/v1/routes/data/test_streaming.py
+++ b/server/tests/unit/application/api/v1/routes/data/test_streaming.py
@@ -87,6 +87,7 @@ async def test_paginated_no_more_rows_null_cursor() -> None:
     resp = await build_table_response(_aiter(rows), JSON_FMT, COLUMNS, _plan(limit=50))
     parsed = json.loads(await _body(resp))
     assert parsed["next_cursor"] is None
+    assert parsed["has_more"] is False
     assert parsed["rows"] == [{"id": "a", "srn": "s1"}, {"id": "b", "srn": "s2"}]
 
 
@@ -102,6 +103,7 @@ async def test_paginated_has_more_emits_cursor() -> None:
     parsed = json.loads(await _body(resp))
     assert len(parsed["rows"]) == 2
     assert parsed["next_cursor"] is not None
+    assert parsed["has_more"] is True
     decoded = json.loads(base64.urlsafe_b64decode(parsed["next_cursor"]))
     # default RECORDS sort is created_at desc, tiebreaker srn
     assert decoded["s"] == "2026-01-02"

--- a/server/tests/unit/domain/data/test_skill_renderer_degradation.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_degradation.py
@@ -95,7 +95,9 @@ class TestOrphanSchema:
 
 
 class TestEmptyColumnSampling:
-    def test_placeholder_when_sample_is_none(self) -> None:
+    def test_template_when_sample_is_none(self) -> None:
+        # No sampled value → the filter example is an explicit fill-in template
+        # (a non-JSON <token>), not a fake-runnable POST, regardless of type.
         out = SkillRenderer().render_reference(
             manifest=_manifest_no_features(),
             docs=None,
@@ -103,7 +105,8 @@ class TestEmptyColumnSampling:
             sample_field="species",
             sample=None,
         )
-        assert '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
+        assert '"value": <species>' in out
+        assert "replace <species> with a real value" in out
 
     def test_examples_still_render_without_any_field(self) -> None:
         manifest = _manifest_no_features().model_copy(update={"fields": []})

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -17,25 +17,8 @@ from osa.domain.data.model.manifest import (
 )
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import AuthorDocs, ExampleDoc, SampleValue
-from osa.domain.data.service.skill_renderer import (
-    PLACEHOLDER_VALUE,
-    SkillRenderer,
-    _example_value_for,
-)
+from osa.domain.data.service.skill_renderer import SkillRenderer
 from osa.domain.semantics.model.value import FieldType
-
-
-class TestExampleValueFallback:
-    def test_numeric_is_castable_literal(self) -> None:
-        assert _example_value_for(FieldType.NUMBER) == 0
-
-    def test_boolean_is_castable_literal(self) -> None:
-        assert _example_value_for(FieldType.BOOLEAN) is False
-
-    def test_text_keeps_replace_me_string(self) -> None:
-        # Text columns accept the string, so keep the clearly-labelled marker.
-        assert _example_value_for(FieldType.TEXT) == PLACEHOLDER_VALUE
-
 
 BASE = "https://archive.university.edu"
 
@@ -223,11 +206,13 @@ class TestMechanicalExamples:
             '"op": "eq", "value": 512}}'
         ) in out
 
-    def test_filter_example_placeholder_when_no_sample(self) -> None:
-        # No sample + numeric field → a castable numeric literal (0), never the
-        # string placeholder (PostgreSQL rejects a string on a numeric column).
+    def test_filter_example_is_a_template_when_no_sample(self) -> None:
+        # No real value to demonstrate → an explicit fill-in template, not a
+        # fake-runnable POST. The <token> is deliberately not valid JSON, so it
+        # can never be mistaken for (and executed as) a real request.
         out = _render(sample=None)
-        assert '"field": "metadata.yield_strength", "op": "eq", "value": 0' in out
+        assert '"field": "metadata.yield_strength", "op": "eq", "value": <yield_strength>' in out
+        assert "replace <yield_strength> with a real value" in out
 
     def test_join_recipe_spells_out_columns(self) -> None:
         out = _render()
@@ -248,11 +233,15 @@ class TestMechanicalExamples:
         out = _render(feature_sample=SampleValue(value=-40))
         assert '"field": "features.ductility.transition_temp", "op": "eq", "value": -40' in out
 
-    def test_feature_filter_example_fallback_is_type_valid(self) -> None:
-        # Empty numeric feature column → a castable numeric literal, not the
-        # string placeholder (which PostgreSQL would reject → 500 on the POST).
+    def test_feature_filter_example_is_a_template_when_no_sample(self) -> None:
+        # Empty feature column → a fill-in template with a non-JSON <token>,
+        # never a fabricated literal presented as a runnable request.
         out = _render(feature_sample=None)
-        assert '"field": "features.ductility.transition_temp", "op": "eq", "value": 0' in out
+        assert (
+            '"field": "features.ductility.transition_temp", "op": "eq", '
+            '"value": <transition_temp>' in out
+        )
+        assert "replace <transition_temp> with a real value" in out
 
     def test_single_record_fetch(self) -> None:
         assert f"GET {BASE}/api/v1/data/records/<id>" in _render()

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -222,6 +222,22 @@ class TestMechanicalExamples:
         assert f"POST {BASE}/api/v1/data/alloy-tests@2.1.0/ductility" in out
         assert '"field": "features.ductility.transition_temp"' in out
 
+    def test_feature_filter_example_uses_sampled_typed_value(self) -> None:
+        # A real sampled value keeps the example castable: transition_temp is
+        # numeric, so the value must be a JSON number, never the string
+        # placeholder (which PostgreSQL would reject for a numeric column).
+        out = _render(feature_sample=SampleValue(value=-40))
+        assert '"field": "features.ductility.transition_temp", "op": "eq", "value": -40' in out
+
+    def test_feature_filter_example_placeholder_only_without_sample(self) -> None:
+        # Empty feature column → the clearly-labelled string placeholder (same
+        # posture as the metadata example), signalling "replace me".
+        out = _render(feature_sample=None)
+        assert (
+            '"field": "features.ductility.transition_temp", "op": "eq", '
+            '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
+        )
+
     def test_single_record_fetch(self) -> None:
         assert f"GET {BASE}/api/v1/data/records/<id>" in _render()
 

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -143,12 +143,34 @@ class TestFeatureTables:
         out = _render()
         assert "## Feature tables" in out
         assert "### ductility" in out
-        assert "| transition_temp | number | float | °C | Ductile-brittle transition |" in out
+        assert (
+            "| transition_temp | number | float | °C | Ductile-brittle transition "
+            "| features.ductility.transition_temp |" in out
+        )
 
     def test_implicit_feature_columns_listed(self) -> None:
         out = _render()
         feature_start = out.index("### ductility")
         assert "| record_srn | text |" in out[feature_start:]
+
+    def test_filter_ref_documented_per_column(self) -> None:
+        # AX-6: the exact filterable ref sits next to each feature column, so an
+        # agent never has to read server source to learn the grammar.
+        out = _render()
+        assert "| Column | Type | Format | Unit | Description | Filter ref |" in out
+        assert "features.ductility.transition_temp |" in out
+
+    def test_coverage_line_when_records_covered_present(self) -> None:
+        manifest = _manifest()
+        feature = next(t for t in manifest.table_resources if t.kind == TableKind.FEATURE)
+        feature.records_covered = 9000
+        out = _render(manifest=manifest)
+        # records total is 12480 → 72%
+        assert "9312 rows · covers 9000 of 12480 records (72%)." in out
+
+    def test_coverage_line_omitted_when_absent(self) -> None:
+        # Default manifest has records_covered=None on the feature resource.
+        assert "covers" not in _render().split("### ductility")[1].split("| Column")[0]
 
 
 class TestJoinKeysAndProvenance:
@@ -192,6 +214,13 @@ class TestMechanicalExamples:
         out = _render()
         assert f"GET {BASE}/api/v1/data/alloy-tests@2.1.0/ductility.csv.gz" in out
         assert "`ductility.record_srn`" in out
+
+    def test_feature_filter_example_uses_feature_field_ref(self) -> None:
+        # AX-6: a runnable feature-column filter (POST to the feature endpoint,
+        # which supports same-hook predicates today), templated on a real column.
+        out = _render()
+        assert f"POST {BASE}/api/v1/data/alloy-tests@2.1.0/ductility" in out
+        assert '"field": "features.ductility.transition_temp"' in out
 
     def test_single_record_fetch(self) -> None:
         assert f"GET {BASE}/api/v1/data/records/<id>" in _render()

--- a/server/tests/unit/domain/data/test_skill_renderer_reference.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_reference.py
@@ -17,8 +17,25 @@ from osa.domain.data.model.manifest import (
 )
 from osa.domain.data.model.query_plan import TableKind
 from osa.domain.data.model.skill import AuthorDocs, ExampleDoc, SampleValue
-from osa.domain.data.service.skill_renderer import SkillRenderer
+from osa.domain.data.service.skill_renderer import (
+    PLACEHOLDER_VALUE,
+    SkillRenderer,
+    _example_value_for,
+)
 from osa.domain.semantics.model.value import FieldType
+
+
+class TestExampleValueFallback:
+    def test_numeric_is_castable_literal(self) -> None:
+        assert _example_value_for(FieldType.NUMBER) == 0
+
+    def test_boolean_is_castable_literal(self) -> None:
+        assert _example_value_for(FieldType.BOOLEAN) is False
+
+    def test_text_keeps_replace_me_string(self) -> None:
+        # Text columns accept the string, so keep the clearly-labelled marker.
+        assert _example_value_for(FieldType.TEXT) == PLACEHOLDER_VALUE
+
 
 BASE = "https://archive.university.edu"
 
@@ -207,8 +224,10 @@ class TestMechanicalExamples:
         ) in out
 
     def test_filter_example_placeholder_when_no_sample(self) -> None:
+        # No sample + numeric field → a castable numeric literal (0), never the
+        # string placeholder (PostgreSQL rejects a string on a numeric column).
         out = _render(sample=None)
-        assert '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
+        assert '"field": "metadata.yield_strength", "op": "eq", "value": 0' in out
 
     def test_join_recipe_spells_out_columns(self) -> None:
         out = _render()
@@ -229,14 +248,11 @@ class TestMechanicalExamples:
         out = _render(feature_sample=SampleValue(value=-40))
         assert '"field": "features.ductility.transition_temp", "op": "eq", "value": -40' in out
 
-    def test_feature_filter_example_placeholder_only_without_sample(self) -> None:
-        # Empty feature column → the clearly-labelled string placeholder (same
-        # posture as the metadata example), signalling "replace me".
+    def test_feature_filter_example_fallback_is_type_valid(self) -> None:
+        # Empty numeric feature column → a castable numeric literal, not the
+        # string placeholder (which PostgreSQL would reject → 500 on the POST).
         out = _render(feature_sample=None)
-        assert (
-            '"field": "features.ductility.transition_temp", "op": "eq", '
-            '"value": "REPLACE_WITH_A_REAL_VALUE"' in out
-        )
+        assert '"field": "features.ductility.transition_temp", "op": "eq", "value": 0' in out
 
     def test_single_record_fetch(self) -> None:
         assert f"GET {BASE}/api/v1/data/records/<id>" in _render()

--- a/server/tests/unit/domain/data/test_skill_renderer_skill.py
+++ b/server/tests/unit/domain/data/test_skill_renderer_skill.py
@@ -7,7 +7,13 @@ trigger-question union; the datasets table carries live counts and
 root-relative reference links.
 """
 
-from osa.domain.data.model.skill import AuthorDocs, DatasetEntry, ExampleDoc, NodeIdentity
+from osa.domain.data.model.skill import (
+    AuthorDocs,
+    DatasetEntry,
+    ExampleDoc,
+    FeatureCoverage,
+    NodeIdentity,
+)
 from osa.domain.data.service.skill_renderer import SkillRenderer, sanitize_skill_name
 
 BASE = "https://archive.university.edu"
@@ -92,6 +98,8 @@ Test-campaign results for structural alloys.
 
 ## Access
 
+Records tables carry identifiers and metadata; the measured and derived science lives in each schema's feature tables (listed in its Reference doc). Join feature rows to records on `record_srn` = `records.srn`.
+
 - Bulk:   GET  https://archive.university.edu/api/v1/data/<schema>/records.csv.gz
 - Filter: POST https://archive.university.edu/api/v1/data/<schema>/records (FilterExpr body — use for large tables)
 - One:    GET  https://archive.university.edu/api/v1/data/records/<id>
@@ -149,3 +157,21 @@ class TestRenderSkillParts:
         )
         assert "api/v1/data/alloy-tests@2.1.0.md" in out
         assert "api/v1/data/alloy-tests.md" not in out
+
+    def test_feature_coverage_surfaced_when_present(self) -> None:
+        # A near-empty feature table must read as an obvious coverage gap, not a
+        # populated table with one row (AX-3): the pilot's predicted_oxygen case.
+        ds = DatasetEntry(
+            schema_ref="strain@1.0.0",
+            title="Strains",
+            row_count=148,
+            features=[FeatureCoverage(name="predicted_oxygen", row_count=1, records_covered=1)],
+        )
+        out = SkillRenderer().render_skill(node=_node(), base_url=BASE, datasets=[ds], docs=[])
+        assert "predicted_oxygen: 1 rows, 1/148 records covered" in out
+
+    def test_feature_coverage_absent_without_features(self) -> None:
+        out = SkillRenderer().render_skill(
+            node=_node(), base_url=BASE, datasets=[_dataset()], docs=[]
+        )
+        assert "records covered" not in out

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1188,7 +1188,7 @@ wheels = [
 
 [[package]]
 name = "osa"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Why

A real AI-agent session against a live node reached a **wrong answer** on a simple
two-table query because the `/data` read surface *silently succeeds* with wrong or
empty data instead of speaking up (issue #168). This PR makes the surface fail loud
and expose what's actually there.

## What

| Item | Change |
|---|---|
| **BUG-1** | `FilterRequestBody` now forbids extra keys — a mis-shaped filter body (e.g. an agent copying a wrong DSL) 422s at the edge instead of running **unfiltered** and returning a plausible page. This was the root cause of the wrong answer. |
| **AX-4** | Paginated JSON reads carry `has_more`, so a *complete* page is distinguishable from a *truncated* one. Threaded from the already-computed `PageSlice.truncated`; MCP `TablePage` already exposed it. |
| **AX-3 / AX-8** | Per-feature **join coverage** (`COUNT(DISTINCT record_srn)`) on the schema manifest (`TableResource.records_covered`), the reference-doc feature sections, and the SKILL.md datasets. A 1-of-148 feature table now reads as an obvious gap. `describe_dataset` gets it free via the manifest. |
| **AX-6** | Each feature column documents its exact filterable ref `features.<hook>.<column>`, plus a runnable feature-filter example — no more reading server source to learn the grammar. |
| **AX-7** | SKILL.md leads with the feature tables + the `record_srn = records.srn` join model, not the id-only records dump. |
| **AX-5** | Audit confirmed the surface already fails loud (named 422s for unknown metadata/feature/sort fields); BUG-1 closes the body-key gap. |

**Not in this PR:** BUG-2 (`/openapi.json` 500) was already fixed on `main`; verified by the
existing backstop test. AX-2 (server-side cross-feature join, #169) is intentionally left
out — tracked separately.

## Testing

- Unit: 1507 passed · Integration (PG): 165 passed · Contract: 43 passed
- `ruff` + `ty`: clean
- TDD throughout (red test first for each behavioural change).

## Notes

- The coverage `COUNT(DISTINCT)` is a live, uncached aggregate — fine at current scale,
  but its cost at millions of rows is tracked in #171.
- Also syncs `uv.lock` (osa `0.0.6` → `0.0.7`, missed by the version-bump commit).

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
