### PR TITLE
feat: scoped M2M read tokens from the extra issuer (#184)

### DIFF
--- a/server/osa/domain/auth/service/token.py
+++ b/server/osa/domain/auth/service/token.py
@@ -31,6 +31,11 @@ class TokenService(Service):
     """
 
     _config: JwtConfig
+    # This node's own public origin (``https://{domain}``), accepted as a valid
+    # audience for extra-issuer tokens alongside the fixed publication audience
+    # (#184). None → only the publication audience is accepted, byte-identical to
+    # before. Irrelevant when no extra issuer is configured.
+    _node_audience: str | None = None
     # Optional second issuer for M2M tokens (#145, US5). None → single-issuer
     # behaviour, byte-identical to before.
     _extra_issuer: ExtraIssuerConfig | None = None
@@ -103,11 +108,18 @@ class TokenService(Service):
             # trusted, so a token can't downgrade to `none`/HS256.
             unverified = jwt.decode(token, options={"verify_signature": False})
             if unverified.get("iss") == self._extra_issuer.issuer:
+                # Accept the fixed publication audience OR this node's own origin
+                # (#184). PyJWT treats a list as a set of acceptable audiences —
+                # the token verifies if its `aud` matches any one. Binding to the
+                # node origin makes cross-node replay of a read token impossible.
+                audiences = [self._extra_issuer.audience]
+                if self._node_audience is not None:
+                    audiences.append(self._node_audience)
                 return jwt.decode(
                     token,
                     self._extra_issuer.public_key,
                     algorithms=["EdDSA"],
-                    audience=self._extra_issuer.audience,
+                    audience=audiences,
                     issuer=self._extra_issuer.issuer,
                 )
 

--- a/server/osa/domain/auth/util/di/provider.py
+++ b/server/osa/domain/auth/util/di/provider.py
@@ -74,6 +74,10 @@ class AuthProvider(Provider):
         """Provide TokenService (stateless, only needs config)."""
         return TokenService(
             _config=config.auth.jwt,
+            # This node's own origin, accepted as a valid audience for
+            # extra-issuer read tokens (#184) — matches what the issuer mints
+            # (`aud: "https://{domain}"`).
+            _node_audience=f"https://{config.domain}",
             _extra_issuer=config.auth.extra_issuer,
         )
 

--- a/server/osa/domain/deposition/query/list_ingesters.py
+++ b/server/osa/domain/deposition/query/list_ingesters.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from osa.domain.auth.model.principal import Principal
 from osa.domain.deposition.service.convention import ConventionService
-from osa.domain.shared.authorization.gate import public
+from osa.domain.shared.authorization.gate import requires_scope
 from osa.domain.shared.model.srn import ConventionSlug
 from osa.domain.shared.query import Query, QueryHandler, Result
 
@@ -36,7 +37,12 @@ class IngesterCatalog(Result):
 
 
 class ListIngestersHandler(QueryHandler[ListIngesters, IngesterCatalog]):
-    __auth__ = public()
+    # Scoped M2M read (#184): the ingester catalog exposes image/digest/source
+    # provenance, so it sits behind `ingesters:read` (OR ADMIN) rather than being
+    # public. The self-host BFF proxies it with a SUPERADMIN token (ADMIN → allowed).
+    __auth__ = requires_scope("ingesters:read")
+
+    principal: Principal
     convention_service: ConventionService
 
     async def run(self, cmd: ListIngesters) -> IngesterCatalog:

--- a/server/osa/domain/ingest/query/get_ingestion.py
+++ b/server/osa/domain/ingest/query/get_ingestion.py
@@ -3,10 +3,9 @@
 from datetime import datetime
 
 from osa.domain.auth.model.principal import Principal
-from osa.domain.auth.model.role import Role
 from osa.domain.ingest.model.ingest_run import IngestRunId, IngestStatus
 from osa.domain.ingest.service.ingest import IngestService
-from osa.domain.shared.authorization.gate import at_least
+from osa.domain.shared.authorization.gate import requires_scope
 from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.query import Query, QueryHandler, Result
 
@@ -42,7 +41,8 @@ class IngestRunDetail(Result):
 class GetIngestionHandler(QueryHandler[GetIngestion, IngestRunDetail]):
     """Thin query handler — delegates to IngestService."""
 
-    __auth__ = at_least(Role.ADMIN)
+    # Scoped M2M read (#184): `ingestions:read` OR ADMIN.
+    __auth__ = requires_scope("ingestions:read")
 
     principal: Principal
     service: IngestService

--- a/server/osa/domain/ingest/query/list_ingestions.py
+++ b/server/osa/domain/ingest/query/list_ingestions.py
@@ -3,10 +3,9 @@
 from datetime import datetime
 
 from osa.domain.auth.model.principal import Principal
-from osa.domain.auth.model.role import Role
 from osa.domain.ingest.model.ingest_run import IngestRunId, IngestStatus
 from osa.domain.ingest.service.ingest import IngestService
-from osa.domain.shared.authorization.gate import at_least
+from osa.domain.shared.authorization.gate import requires_scope
 from osa.domain.shared.failure import FailureKind
 from osa.domain.shared.query import Query, QueryHandler, Result
 
@@ -37,7 +36,9 @@ class IngestRunList(Result):
 
 
 class ListIngestionsHandler(QueryHandler[ListIngestions, IngestRunList]):
-    __auth__ = at_least(Role.ADMIN)
+    # Scoped M2M read (#184): a token with `ingestions:read` reads this surface;
+    # ADMIN still passes (RequiresScope authorizes on scope OR ADMIN).
+    __auth__ = requires_scope("ingestions:read")
 
     principal: Principal
     service: IngestService

--- a/server/tests/unit/domain/auth/test_ingest_read_scopes.py
+++ b/server/tests/unit/domain/auth/test_ingest_read_scopes.py
@@ -1,0 +1,129 @@
+"""Scoped M2M read access to the operational ingest surfaces (#184).
+
+`GET /ingestions` (list + detail) and `GET /ingesters` are gated by a single
+OAuth read scope each, so a properly-scoped M2M token reads exactly its surface
+without conferring ADMIN elsewhere. RequiresScope authorizes on scope OR ADMIN,
+so existing ADMIN/self-host access is preserved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from osa.domain.auth.model.identity import Anonymous
+from osa.domain.auth.model.principal import Principal
+from osa.domain.auth.model.role import Role
+from osa.domain.auth.model.value import ProviderIdentity, UserId
+from osa.domain.deposition.query.list_ingesters import (
+    ListIngesters,
+    ListIngestersHandler,
+)
+from osa.domain.ingest.query.get_ingestion import GetIngestion, GetIngestionHandler
+from osa.domain.ingest.query.list_ingestions import (
+    ListIngestions,
+    ListIngestionsHandler,
+)
+from osa.domain.ingest.model.ingest_run import IngestRunId
+from osa.domain.shared.authorization.gate import requires_scope
+from osa.domain.shared.error import AuthorizationError
+
+
+def _principal(
+    *, roles: frozenset[Role] = frozenset(), scopes: frozenset[str] = frozenset()
+) -> Principal:
+    return Principal(
+        user_id=UserId.generate(),
+        provider_identity=ProviderIdentity(provider="m2m", external_id="client-1"),
+        roles=roles,
+        scopes=scopes,
+    )
+
+
+class TestGateDeclarations:
+    def test_list_ingestions_requires_ingestions_read(self) -> None:
+        assert ListIngestionsHandler.__auth__ == requires_scope("ingestions:read")
+
+    def test_get_ingestion_requires_ingestions_read(self) -> None:
+        assert GetIngestionHandler.__auth__ == requires_scope("ingestions:read")
+
+    def test_list_ingesters_requires_ingesters_read(self) -> None:
+        assert ListIngestersHandler.__auth__ == requires_scope("ingesters:read")
+
+
+class TestListIngestionsAuth:
+    @pytest.mark.asyncio
+    async def test_allows_matching_scope(self) -> None:
+        service = AsyncMock()
+        service.list_ingestions.return_value = []
+        handler = ListIngestionsHandler(
+            principal=_principal(scopes=frozenset({"ingestions:read"})),
+            service=service,
+        )
+        result = await handler.run(ListIngestions())
+        assert result.items == []
+
+    @pytest.mark.asyncio
+    async def test_allows_admin_without_scope(self) -> None:
+        service = AsyncMock()
+        service.list_ingestions.return_value = []
+        handler = ListIngestionsHandler(
+            principal=_principal(roles=frozenset({Role.ADMIN})),
+            service=service,
+        )
+        assert (await handler.run(ListIngestions())).items == []
+
+    @pytest.mark.asyncio
+    async def test_denies_wrong_scope(self) -> None:
+        # A stats:read token cannot read the ingestions surface.
+        handler = ListIngestionsHandler(
+            principal=_principal(scopes=frozenset({"stats:read"})),
+            service=AsyncMock(),
+        )
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(ListIngestions())
+        assert exc.value.code == "access_denied"
+
+    @pytest.mark.asyncio
+    async def test_denies_anonymous(self) -> None:
+        handler = ListIngestionsHandler(principal=Anonymous(), service=AsyncMock())  # type: ignore[arg-type]
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(ListIngestions())
+        assert exc.value.code == "missing_token"
+
+
+class TestGetIngestionAuth:
+    @pytest.mark.asyncio
+    async def test_denies_wrong_scope(self) -> None:
+        handler = GetIngestionHandler(
+            principal=_principal(scopes=frozenset({"ingesters:read"})),
+            service=AsyncMock(),
+        )
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(GetIngestion(ingest_run_id=IngestRunId("run-1")))
+        assert exc.value.code == "access_denied"
+
+
+class TestListIngestersAuth:
+    @pytest.mark.asyncio
+    async def test_allows_matching_scope(self) -> None:
+        service = AsyncMock()
+        service.list_conventions_with_source.return_value = []
+        handler = ListIngestersHandler(
+            principal=_principal(scopes=frozenset({"ingesters:read"})),
+            convention_service=service,
+        )
+        result = await handler.run(ListIngesters())
+        assert result.items == []
+
+    @pytest.mark.asyncio
+    async def test_denies_wrong_scope(self) -> None:
+        # An ingestions:read token cannot read the ingesters catalog.
+        handler = ListIngestersHandler(
+            principal=_principal(scopes=frozenset({"ingestions:read"})),
+            convention_service=AsyncMock(),
+        )
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(ListIngesters())
+        assert exc.value.code == "access_denied"

--- a/server/tests/unit/domain/auth/test_token_iss_routing.py
+++ b/server/tests/unit/domain/auth/test_token_iss_routing.py
@@ -22,6 +22,8 @@ from osa.domain.auth.service.token import TokenService
 
 ISSUER = "https://deploy.example.org"
 AUDIENCE = "osa-deploy"
+NODE_ORIGIN = "https://node-a.example.org"
+OTHER_NODE_ORIGIN = "https://node-b.example.org"
 
 
 def _ed25519_keypair() -> tuple[bytes, str]:
@@ -61,11 +63,12 @@ def _m2m_token(
     algorithm: str = "EdDSA",
     scope: str = "hooks:write",
     iss: str = ISSUER,
+    aud: str = AUDIENCE,
 ) -> str:
     return jwt.encode(
         {
             "iss": iss,
-            "aud": AUDIENCE,
+            "aud": aud,
             "sub": "deploy-bot",
             "scope": scope,
             "exp": int(time.time()) + 3600,
@@ -140,3 +143,55 @@ class TestExtraIssuerPath:
         service = TokenService(_config=_jwt_config(), _extra_issuer=_extra(ed_public))
         with pytest.raises(jwt.InvalidTokenError):
             service.validate_access_token(_m2m_token(rsa_private, algorithm="RS256"))
+
+
+class TestPerNodeAudience:
+    """A node also accepts extra-issuer tokens minted for its own origin (#184).
+
+    The node accepts BOTH the fixed publication audience and its own origin
+    ``https://{domain}``, so read tokens (``aud == node origin``) verify locally
+    while a token minted for a *different* node's origin is rejected — cross-node
+    replay is structurally impossible.
+    """
+
+    def _service(self, public_pem: str) -> TokenService:
+        return TokenService(
+            _config=_jwt_config(),
+            _node_audience=NODE_ORIGIN,
+            _extra_issuer=_extra(public_pem),
+        )
+
+    def test_node_origin_audience_accepted(self, keypair) -> None:
+        private_pem, public_pem = keypair
+        service = self._service(public_pem)
+        payload = service.validate_access_token(
+            _m2m_token(private_pem, scope="stats:read", aud=NODE_ORIGIN)
+        )
+        assert payload["scope"] == "stats:read"
+        assert payload["aud"] == NODE_ORIGIN
+
+    def test_publication_audience_still_accepted(self, keypair) -> None:
+        # Regression: the fixed publication audience keeps verifying even once
+        # the node origin is also accepted (the publication flow is unchanged).
+        private_pem, public_pem = keypair
+        service = self._service(public_pem)
+        payload = service.validate_access_token(
+            _m2m_token(private_pem, scope="conventions:write", aud=AUDIENCE)
+        )
+        assert payload["scope"] == "conventions:write"
+
+    def test_cross_node_replay_rejected(self, keypair) -> None:
+        # A token minted for a sibling node's origin does not verify here.
+        private_pem, public_pem = keypair
+        service = self._service(public_pem)
+        with pytest.raises(jwt.InvalidTokenError):
+            service.validate_access_token(_m2m_token(private_pem, aud=OTHER_NODE_ORIGIN))
+
+    def test_node_origin_rejected_without_it_configured(self, keypair) -> None:
+        # Without a node audience configured, only the publication audience is
+        # accepted — a node-origin token is rejected (behaviour byte-identical
+        # to before #184).
+        private_pem, public_pem = keypair
+        service = TokenService(_config=_jwt_config(), _extra_issuer=_extra(public_pem))
+        with pytest.raises(jwt.InvalidTokenError):
+            service.validate_access_token(_m2m_token(private_pem, aud=NODE_ORIGIN))


### PR DESCRIPTION
Closes #184.

Extends the `extra_issuer` M2M path (#145) so a trusted external issuer can mint scoped **read** tokens, not just the publication token.

## Changes

### 1. Per-node audience (replay protection)
`TokenService.validate_access_token` now accepts **either** the fixed publication audience **or** this node's own origin (`https://{domain}`) as a valid `aud` for extra-issuer tokens (`audience=[extra_issuer.audience, node_audience]`). The node origin is wired from `config.domain` in the DI provider, matching what the issuer mints (`aud: "https://{domain}"`, opensciencearchive/cloud#84).

Binding `aud` to the node origin makes cross-node replay of a read token structurally impossible: a token minted for a sibling node fails standard `aud` validation here. The publication flow keeps its fixed audience — unchanged, fleet-wide by design.

### 2. Scope enforcement on the operational read surfaces
The scope machinery (`Principal.scopes`, the `RequiresScope` gate, gate enforcement in the command/query metaclasses) already existed from #145; this wires the ingest read surfaces onto it:

| Endpoint | Before | After |
|---|---|---|
| `GET /ingestions` (list + detail) | `at_least(ADMIN)` | `requires_scope("ingestions:read")` |
| `GET /ingesters` | `public()` | `requires_scope("ingesters:read")` |

`RequiresScope` authorizes on **scope OR ADMIN**, so existing ADMIN / self-host-BFF (SUPERADMIN token) access is preserved; a mis-scoped M2M token (e.g. `stats:read`) is denied. `GET /ingesters` is *tightened* from public — it exposes ingester image/digest/source provenance that belongs behind the operational scope.

The genuinely public catalog/health surfaces (`/stats`, `/data/*`, `/schemas`, `/hooks`, `/ready`) stay public ("public endpoints stay public; scopes … for future tightening").

## Acceptance criteria
- [x] Extra-issuer token with `aud == node origin` + `scope: stats:read` verifies; a token minted for a different origin is rejected (replay test).
- [x] `ingesters:read` / `ingestions:read` tokens read their surface and nothing else (`stats:read` cannot read `/ingestions`).
- [x] `conventions:write` publication tokens with the fixed audience continue to verify (regression pinned).
- [x] `iss`-routing for the primary HS256 path unchanged (SC-007 green).

## Tests
- `test_token_iss_routing.py`: added `TestPerNodeAudience` (node-origin accept, publication-audience regression, cross-node replay reject, and no-node-audience-configured behaviour); primary-path (SC-007) tests untouched.
- `test_ingest_read_scopes.py` (new): pins each handler's gate and covers matching-scope allow / ADMIN allow / wrong-scope deny / anonymous deny.
- Full unit suite green (1524 passed); ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)