### PR TITLE
ci(dashboard): publish self-host + platform image variants (#185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,9 @@ jobs:
           OSA_AUTH__JWT__SECRET: test-secret-for-integration-tests-minimum-32-chars
           TEST: "1"
 
-  # Build & push Docker image (main + PRs onto main, gated on all server checks)
-  image:
+  # Build & push the server image (main + PRs onto main, gated on all server
+  # checks). Only when server code changed.
+  server-image:
     name: Server - Image
     needs: [changes, server-lint, server-typecheck, server-test, server-contract, server-integration]
     if: >-
@@ -221,7 +222,22 @@ jobs:
         github.ref == 'refs/heads/main' ||
         (github.event_name == 'pull_request' && github.base_ref == 'main')
       )
-    uses: ./.github/workflows/image.yml
+    uses: ./.github/workflows/server-image.yml
+    permissions:
+      contents: read
+      packages: write
+
+  # Build & push the dashboard image variants (main + PRs onto main, gated on the
+  # dashboard check). Only when dashboard code changed — independent of the server.
+  dashboard-image:
+    name: Dashboard - Image
+    needs: [changes, dashboard-check]
+    if: >-
+      needs.changes.outputs.dashboard == 'true' && (
+        github.ref == 'refs/heads/main' ||
+        (github.event_name == 'pull_request' && github.base_ref == 'main')
+      )
+    uses: ./.github/workflows/dashboard-image.yml
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -44,15 +44,24 @@ jobs:
 
       - name: Compute tags
         id: tags
+        # Pass event metadata through env, never interpolated into the script —
+        # a release tag / branch name is untrusted input, and `${{ }}` inside a
+        # run block would let shell syntax in it execute under packages:write.
+        env:
+          IMAGE: ${{ env.IMAGE_DASHBOARD }}
+          PREFIX: ${{ matrix.tag_prefix }}
+          SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PREFIX="${{ matrix.tag_prefix }}"
-          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          TAGS="${{ env.IMAGE_DASHBOARD }}:${PREFIX}sha-${SHA_SHORT}"
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:${PREFIX}${{ github.event.release.tag_name }}"
+          SHA_SHORT="${SHA:0:7}"
+          TAGS="${IMAGE}:${PREFIX}sha-${SHA_SHORT}"
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            TAGS="${TAGS},${IMAGE}:${PREFIX}${RELEASE_TAG}"
           fi
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:${PREFIX}pr-${{ github.event.pull_request.number }}"
+          if [[ -n "${PR_NUMBER}" ]]; then
+            TAGS="${TAGS},${IMAGE}:${PREFIX}pr-${PR_NUMBER}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -1,0 +1,68 @@
+name: Dashboard Image
+
+on:
+  workflow_call:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_DASHBOARD: ghcr.io/${{ github.repository_owner }}/osa-dashboard
+
+jobs:
+  # Self-hostable management dashboard (#173). Published in two variants from the
+  # one Dockerfile (#185): the default self-host image (IS_PLATFORM=false, pulled
+  # by the CLI via OSA_IMAGE_VERSION) and a `platform-`-prefixed image
+  # (IS_PLATFORM=true) that the hosted control plane deploys. NEXT_PUBLIC_* are
+  # inlined at build, so the mode is fixed per image — hence one build per variant.
+  dashboard:
+    name: Build & Push (${{ matrix.variant }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: self-host
+            is_platform: "false"
+            tag_prefix: ""
+          - variant: platform
+            is_platform: "true"
+            tag_prefix: "platform-"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          PREFIX="${{ matrix.tag_prefix }}"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          TAGS="${{ env.IMAGE_DASHBOARD }}:${PREFIX}sha-${SHA_SHORT}"
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:${PREFIX}${{ github.event.release.tag_name }}"
+          fi
+          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
+            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:${PREFIX}pr-${{ github.event.pull_request.number }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: apps/dashboard
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=dashboard-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=dashboard-${{ matrix.variant }}
+          build-args: |
+            NEXT_PUBLIC_IS_PLATFORM=${{ matrix.is_platform }}
+            NEXT_PUBLIC_API_MODE=real

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -52,14 +52,23 @@ jobs:
 
       - name: Compute tags
         id: tags
+        # Pass event metadata through env, never interpolated into the script —
+        # a release tag / branch name is untrusted input, and `${{ }}` inside a
+        # run block would let shell syntax in it execute under packages:write.
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          TAGS="${{ env.IMAGE }}:sha-${SHA_SHORT}"
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE }}:${{ github.event.release.tag_name }}"
+          SHA_SHORT="${SHA:0:7}"
+          TAGS="${IMAGE}:sha-${SHA_SHORT}"
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            TAGS="${TAGS},${IMAGE}:${RELEASE_TAG}"
           fi
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE }}:pr-${{ github.event.pull_request.number }}"
+          if [[ -n "${PR_NUMBER}" ]]; then
+            TAGS="${TAGS},${IMAGE}:pr-${PR_NUMBER}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -1,4 +1,4 @@
-name: Image
+name: Server Image
 
 on:
   workflow_call:
@@ -8,7 +8,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/osa
-  IMAGE_DASHBOARD: ghcr.io/${{ github.repository_owner }}/osa-dashboard
 
 jobs:
   build:
@@ -74,46 +73,3 @@ jobs:
           build-args: |
             OSA_VERSION=${{ github.event.release.tag_name || github.sha }}
             OSA_REVISION=${{ github.sha }}
-
-  # Self-hostable management dashboard (#173). Built as a self-host image
-  # (IS_PLATFORM=false); the CLI pulls it by release tag via OSA_IMAGE_VERSION.
-  dashboard:
-    name: Dashboard - Build & Push
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags
-        id: tags
-        run: |
-          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          TAGS="${{ env.IMAGE_DASHBOARD }}:sha-${SHA_SHORT}"
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:${{ github.event.release.tag_name }}"
-          fi
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            TAGS="${TAGS},${{ env.IMAGE_DASHBOARD }}:pr-${{ github.event.pull_request.number }}"
-          fi
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: apps/dashboard
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha,scope=dashboard
-          cache-to: type=gha,mode=max,scope=dashboard
-          build-args: |
-            NEXT_PUBLIC_IS_PLATFORM=false
-            NEXT_PUBLIC_API_MODE=real


### PR DESCRIPTION
Part of #185 (the CI variant split — the runtime `AMACRIN_API_URL` / platform-BFF work follows separately).

## What

Publish the dashboard container in **two variants from the one Dockerfile**:

| Tag | Build arg | Consumer |
|---|---|---|
| `osa-dashboard:<tag>` | `NEXT_PUBLIC_IS_PLATFORM=false` | self-host (default, unchanged) |
| `osa-dashboard:platform-<tag>` | `NEXT_PUBLIC_IS_PLATFORM=true` | hosted control plane (EKS) |

`NEXT_PUBLIC_*` values are inlined at `next build`, so the mode is fixed per image — the platform mode can't be flipped at deploy time, hence a second build. Implemented as a `strategy.matrix` dimension with distinct buildx cache scopes (`dashboard-self-host` / `dashboard-platform`). No Dockerfile change.

## Also: split the reusable image workflow + trigger on dashboard changes

The single `image.yml` (which built server **and** dashboard in one call, gated only on server changes) is split into two single-responsibility reusable workflows — `server-image.yml` and `dashboard-image.yml` — each with its own caller job in `ci.yml`:

- `server-image` — `needs` the server checks, gated on `server` changes.
- `dashboard-image` — `needs` `dashboard-check`, gated on `dashboard` changes.

So **dashboard image builds now trigger on dashboard code changes** (previously they only ran when server code changed). Splitting avoids the alternative — one job `needs`-ing both components' checks and using `!failure()` to tolerate the skipped ones — which is fragile. On `release: published` both workflows trigger independently, so release tagging keeps building both images.

## Acceptance criteria (this PR)
- [x] A release publishes both tags (`:<tag>` and `:platform-<tag>`).
- [x] The self-host tag is byte-identical in behaviour to today's image (same build args, same context).
- [ ] "Platform image boots with `AMACRIN_API_URL` at runtime / no baked API URL" — deferred to the platform-BFF PR.

## Verification
YAML validated; job graph confirmed (`server-image`, `dashboard-image` callers; `build` / `dashboard` reusable jobs). CI image jobs run on `main`/PR-to-`main`, so they'll exercise on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)