### PR TITLE
feat: accept the ingestions:write M2M scope on POST /ingestions

### DIFF
--- a/server/osa/domain/ingest/command/start_ingest.py
+++ b/server/osa/domain/ingest/command/start_ingest.py
@@ -1,7 +1,6 @@
 """StartIngest command — initiates a bulk ingestion run for a convention."""
 
-from osa.domain.auth.model.role import Role
-from osa.domain.shared.authorization.gate import at_least
+from osa.domain.shared.authorization.gate import requires_scope
 from osa.domain.shared.command import Command, CommandHandler, Result
 
 
@@ -25,7 +24,11 @@ class IngestRunCreated(Result):
 class StartIngestHandler(CommandHandler[StartIngest, IngestRunCreated]):
     """Thin command handler — delegates to IngestService."""
 
-    __auth__ = at_least(Role.ADMIN)
+    # Triggering an ingestion run is authorized by the ``ingestions:write``
+    # M2M scope OR an ADMIN role (server#190). The scope lets the hosted
+    # control plane broker CLI/dashboard triggers with a per-node, single-scope
+    # token; ADMIN keeps human/self-host access unchanged.
+    __auth__ = requires_scope("ingestions:write")
 
     # TODO: do we ned these imports to be lazy?
     from osa.domain.auth.model.principal import Principal

--- a/server/tests/unit/domain/auth/test_ingest_write_scopes.py
+++ b/server/tests/unit/domain/auth/test_ingest_write_scopes.py
@@ -1,0 +1,92 @@
+"""Scoped M2M write access to the ingest trigger (server#190).
+
+`POST /ingestions` (start an ingestion run) is gated by the `ingestions:write`
+OAuth scope, so the hosted control plane can broker CLI/dashboard-triggered
+runs with a per-node, single-scope M2M token — without a tenant ORCID/admin
+session. RequiresScope authorizes on scope OR ADMIN, so existing ADMIN and
+self-host access is preserved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from osa.domain.auth.model.identity import Anonymous
+from osa.domain.auth.model.principal import Principal
+from osa.domain.auth.model.role import Role
+from osa.domain.auth.model.value import ProviderIdentity, UserId
+from osa.domain.ingest.command.start_ingest import StartIngest, StartIngestHandler
+from osa.domain.shared.authorization.gate import requires_scope
+from osa.domain.shared.error import AuthorizationError
+
+
+def _principal(
+    *, roles: frozenset[Role] = frozenset(), scopes: frozenset[str] = frozenset()
+) -> Principal:
+    return Principal(
+        user_id=UserId.generate(),
+        provider_identity=ProviderIdentity(provider="m2m", external_id="client-1"),
+        roles=roles,
+        scopes=scopes,
+    )
+
+
+def _ingest_run() -> object:
+    from datetime import datetime, timezone
+
+    run = AsyncMock()
+    run.id = "ing_1"
+    run.convention_id = "cultivarium"
+    run.status = "pending"
+    run.started_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    return run
+
+
+def _service() -> AsyncMock:
+    from osa.domain.shared.model.srn import Domain
+
+    service = AsyncMock()
+    service.start_ingest.return_value = _ingest_run()
+    service.node_domain = Domain(root="cultivarium.amacr.in")
+    return service
+
+
+class TestGateDeclaration:
+    def test_start_ingest_requires_ingestions_write(self) -> None:
+        assert StartIngestHandler.__auth__ == requires_scope("ingestions:write")
+
+
+class TestStartIngestAuth:
+    async def test_allows_matching_scope(self) -> None:
+        handler = StartIngestHandler(
+            principal=_principal(scopes=frozenset({"ingestions:write"})),
+            service=_service(),
+        )
+        result = await handler.run(StartIngest(convention_id="cultivarium"))
+        assert result.convention_id == "cultivarium"
+
+    async def test_allows_admin_without_scope(self) -> None:
+        handler = StartIngestHandler(
+            principal=_principal(roles=frozenset({Role.ADMIN})),
+            service=_service(),
+        )
+        result = await handler.run(StartIngest(convention_id="cultivarium"))
+        assert result.status == "pending"
+
+    async def test_denies_wrong_scope(self) -> None:
+        # A read-scoped token cannot trigger a run.
+        handler = StartIngestHandler(
+            principal=_principal(scopes=frozenset({"ingestions:read"})),
+            service=_service(),
+        )
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(StartIngest(convention_id="cultivarium"))
+        assert exc.value.code == "access_denied"
+
+    async def test_denies_anonymous(self) -> None:
+        handler = StartIngestHandler(principal=Anonymous(), service=_service())
+        with pytest.raises(AuthorizationError) as exc:
+            await handler.run(StartIngest(convention_id="cultivarium"))
+        assert exc.value.code == "missing_token"


### PR DESCRIPTION
Closes #190.

## Why

`POST /api/v1/ingestions` was `at_least(Role.ADMIN)`, so a cloud archive had no way to trigger ingestion without a tenant ORCID/admin session — and hosted archives deployed without ORCID have no admin principal at all. The hosted control plane can't use a tenant session; it holds a platform token the tenant (correctly) doesn't trust.

## What

Gate `StartIngestHandler` on `requires_scope("ingestions:write")` instead. `RequiresScope` authorizes on **scope OR ADMIN**, so:
- the hosted control plane brokers CLI/dashboard triggers with a per-node, single-scope M2M token (opensciencearchive/cloud#90 mints exactly `iss=api.amacrin.com`, `aud=https://{node}`, `scope=ingestions:write`);
- human/self-host ADMIN sessions keep working unchanged.

Mirrors the `ingestions:read` gates from #184; the extra-issuer validation (per-node audience, EdDSA, scope parsing) is already in place — this is one gate swap.

## Tests

New `test_ingest_write_scopes.py` (mirrors `test_ingest_read_scopes.py`): gate declaration, allows `ingestions:write`, allows ADMIN without scope, denies a read-only scope (`ingestions:read` can't trigger), denies anonymous. The scope-accept + declaration tests fail against the old ADMIN gate. Full suite green (1601 passed), ruff + ty clean.

## Completes the brokered ingest path

- opensciencearchive/cloud#90 — broker endpoint (mints the token)
- amacrin-labs/cli#6 — CLI routes through the broker

🤖 Generated with [Claude Code](https://claude.com/claude-code)